### PR TITLE
Refactor passenger filtering

### DIFF
--- a/app/assets/stylesheets/passengers.scss
+++ b/app/assets/stylesheets/passengers.scss
@@ -99,8 +99,8 @@ table#key, table#passengers {
 
 .passenger-filters{
   display: inline;
-  checkbox{
-    margin-right: 10px;
+  input{
+    margin-right: 15px;
   }
 }
 

--- a/app/assets/stylesheets/passengers.scss
+++ b/app/assets/stylesheets/passengers.scss
@@ -92,8 +92,16 @@ table#key, table#passengers {
     background-color: #E898FF;
   }
 }
+
 .checkbox-inline.key_position {
   float: right;
+}
+
+.passenger-filters{
+  display: inline;
+  checkbox{
+    margin-right: 10px;
+  }
 }
 
 table#key {

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -14,18 +14,22 @@ class PassengersController < ApplicationController
 
   # TODO: refactor for complexity
   def index
-    if params[:filter].present?
-      @permanent = params[:filter] == 'permanent'
-      @temporary = params[:filter] == 'temporary'
-      @inactive = params[:filter] == 'inactive'
-      @active = params[:filter] == 'active'
-    else @active = true
-    end
     @passengers = Passenger.order :name
-    @passengers = @passengers.permanent if @permanent
-    @passengers = @passengers.temporary if @temporary
-    @passengers = @passengers.inactive if @inactive
-    @passengers = @passengers.active if @active
+
+    if params[:filter].present?
+      if params[:filter] == 'permanent'
+        @permanent = true
+        @passengers = @passengers.permanent
+      else
+        @temporary = true
+        @passengers = @passengers.temporary
+      end
+    end
+
+    if params[:show_inactive]
+      @show_inactive = true
+    else @passengers = @passengers.active
+    end
   end
 
   def create

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -14,10 +14,13 @@ class PassengersController < ApplicationController
 
   # TODO: refactor for complexity
   def index
-    @permanent = params[:filter] == 'permanent'
-    @temporary = params[:filter] == 'temporary'
-    @inactive = params[:filter] == 'inactive'
-    @active = params[:filter] == 'active'
+    if params[:filter].present?
+      @permanent = params[:filter] == 'permanent'
+      @temporary = params[:filter] == 'temporary'
+      @inactive = params[:filter] == 'inactive'
+      @active = params[:filter] == 'active'
+    else @active = true
+    end
     @passengers = Passenger.order :name
     @passengers = @passengers.permanent if @permanent
     @passengers = @passengers.temporary if @temporary

--- a/app/views/passengers/index.haml
+++ b/app/views/passengers/index.haml
@@ -7,17 +7,14 @@
   %p
   = label_tag 'Filter by Type:'
   .passenger-filters
-    Permanent
-    = check_box_tag :filter, 'permanent', @permanent
-    .checkbox-inline
-    Temporary
-    = check_box_tag :filter, 'temporary', @temporary
-    .checkbox-inline
-    Inactive
-    = check_box_tag :filter, 'inactive', @inactive
-    .checkbox-inline
-    Active
-    = check_box_tag :filter, 'active', @active
+    Permanent Only
+    = radio_button_tag :filter, 'permanent', @permanent
+    Temporary Only
+    = radio_button_tag :filter, 'temporary', @temporary
+    All
+    = radio_button_tag :filter, '', !(@permanent || @temporary)
+    Show Inactive
+    = check_box_tag :show_inactive, true, @show_inactive
   .checkbox-inline
   = submit_tag "Find passengers"
   .checkbox-inline.key_position

--- a/app/views/passengers/index.haml
+++ b/app/views/passengers/index.haml
@@ -7,19 +7,16 @@
   %p
   = label_tag 'Filter by Type:'
   Permanent
-  = radio_button_tag :filter, 'permanent'
+  = check_box_tag :filter, 'permanent', @permanent
   .checkbox-inline
   Temporary
-  = radio_button_tag :filter, 'temporary'
+  = check_box_tag :filter, 'temporary', @temporary
   .checkbox-inline
   Inactive
-  = radio_button_tag :filter, 'inactive'
+  = check_box_tag :filter, 'inactive', @inactive
   .checkbox-inline
-  Only Active
-  = radio_button_tag :filter, 'active'
-  .checkbox-inline
-  Show All
-  = radio_button_tag :filter, 'all'
+  Active
+  = check_box_tag :filter, 'active', @active
   .checkbox-inline
   = submit_tag "Find passengers"
   .checkbox-inline.key_position

--- a/app/views/passengers/index.haml
+++ b/app/views/passengers/index.haml
@@ -6,17 +6,18 @@
 = form_tag passengers_path, method: :get do
   %p
   = label_tag 'Filter by Type:'
-  Permanent
-  = check_box_tag :filter, 'permanent', @permanent
-  .checkbox-inline
-  Temporary
-  = check_box_tag :filter, 'temporary', @temporary
-  .checkbox-inline
-  Inactive
-  = check_box_tag :filter, 'inactive', @inactive
-  .checkbox-inline
-  Active
-  = check_box_tag :filter, 'active', @active
+  .passenger-filters
+    Permanent
+    = check_box_tag :filter, 'permanent', @permanent
+    .checkbox-inline
+    Temporary
+    = check_box_tag :filter, 'temporary', @temporary
+    .checkbox-inline
+    Inactive
+    = check_box_tag :filter, 'inactive', @inactive
+    .checkbox-inline
+    Active
+    = check_box_tag :filter, 'active', @active
   .checkbox-inline
   = submit_tag "Find passengers"
   .checkbox-inline.key_position


### PR DESCRIPTION
Closes #30.

<img width="635" alt="screen shot 2017-08-23 at 2 02 05 pm" src="https://user-images.githubusercontent.com/3988134/29630865-aafb6cb6-880b-11e7-97a2-7c98c841da8e.png">

Default is show both permanent & temporary, and hide inactive (show only active). You can select whether to see temporary, permanent, or both; and then (separately) whether to show inactive.

Previously was just one radio button, which didn't allow for combining the filters.