### PR TITLE
Manage mobility devices

### DIFF
--- a/app/assets/stylesheets/mobility_devices.scss
+++ b/app/assets/stylesheets/mobility_devices.scss
@@ -1,0 +1,10 @@
+table#mobility-devices{
+  th{
+    background: lightgrey;
+    text-align: center;
+  }
+
+  th, td{
+    padding: 5px;
+  }
+}

--- a/app/controllers/mobility_devices_controller.rb
+++ b/app/controllers/mobility_devices_controller.rb
@@ -7,14 +7,16 @@ class MobilityDevicesController < ApplicationController
     @device = MobilityDevice.new(device_params)
 
     if @device.save
-      redirect_to mobility_devices_url, notice: 'Mobility device was successfully created.'
+      redirect_to mobility_devices_url,
+                  notice: 'Mobility device was successfully created.'
     else render :new
     end
   end
 
   def destroy
     @device.destroy
-    redirect_to mobility_devices_url, notice: 'Mobility device was successfully destroyed.'
+    redirect_to mobility_devices_url,
+                notice: 'Mobility device was successfully destroyed.'
   end
 
   def index
@@ -27,7 +29,8 @@ class MobilityDevicesController < ApplicationController
 
   def update
     if @device.update(device_params)
-      redirect_to mobility_devices_url, notice: 'Mobility device was successfully updated.'
+      redirect_to mobility_devices_url,
+                  notice: 'Mobility device was successfully updated.'
     else render :edit
     end
   end
@@ -40,6 +43,6 @@ class MobilityDevicesController < ApplicationController
   end
 
   def device_params
-    params.require(:mobility_device).permit(:device, :needs_longer_rides)
+    params.require(:mobility_device).permit :device, :needs_longer_rides
   end
 end

--- a/app/controllers/mobility_devices_controller.rb
+++ b/app/controllers/mobility_devices_controller.rb
@@ -40,6 +40,6 @@ class MobilityDevicesController < ApplicationController
   end
 
   def device_params
-    params.require(:device).permit(:device, :needs_longer_rides)
+    params.require(:mobility_device).permit(:device, :needs_longer_rides)
   end
 end

--- a/app/controllers/mobility_devices_controller.rb
+++ b/app/controllers/mobility_devices_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class MobilityDevicesController < ApplicationController
+  before_action :set_device, only: %i[destroy edit update]
+
+  def create
+    @device = MobilityDevice.new(device_params)
+
+    if @device.save
+      redirect_to mobility_devices_url, notice: 'Mobility device was successfully created.'
+    else render :new
+    end
+  end
+
+  def destroy
+    @device.destroy
+    redirect_to mobility_devices_url, notice: 'Mobility device was successfully destroyed.'
+  end
+
+  def index
+    @devices = MobilityDevice.order :device
+  end
+
+  def new
+    @device = MobilityDevice.new
+  end
+
+  def update
+    if @device.update(device_params)
+      redirect_to mobility_devices_url, notice: 'Mobility device was successfully updated.'
+    else render :edit
+    end
+  end
+
+  private
+
+  def set_device
+    @device = MobilityDevice.find_by id: params.require(:id)
+    head :not_found unless @device.present?
+  end
+
+  def device_params
+    params.require(:device).permit(:device, :needs_longer_rides)
+  end
+end

--- a/app/models/mobility_device.rb
+++ b/app/models/mobility_device.rb
@@ -3,5 +3,5 @@
 class MobilityDevice < ApplicationRecord
   validates :device, presence: true, uniqueness: true
 
-  has_many :passengers
+  has_many :passengers, dependent: :restrict_with_error
 end

--- a/app/views/layouts/_navbar.haml
+++ b/app/views/layouts/_navbar.haml
@@ -5,5 +5,6 @@
     = navbar_link 'Dispatch Log', log_index_url
     - if @current_user.admin?
       = navbar_link 'Manage Users', users_url
+      = navbar_link 'Manage Mobility Devices', mobility_devices_url
     = link_to destroy_session_url do
       %button.btn.btn-default.navbar-btn.navbar-right Logout

--- a/app/views/mobility_devices/_form.haml
+++ b/app/views/mobility_devices/_form.haml
@@ -1,0 +1,17 @@
+= form_for @device do |f|
+  - if @device.errors.any?
+    #error_explanation
+      %h2 
+        = pluralize @device.errors.count, 'error'
+        prohibited this user from being saved:
+      %ul
+        - @device.errors.full_messages.each do |message|
+          %li= message
+  .field
+    = f.label :device
+    = f.text_field :device
+  .field
+    = f.label :needs_longer_rides
+    = f.check_box :needs_longer_rides
+  .actions
+    = f.submit 'Save'

--- a/app/views/mobility_devices/edit.haml
+++ b/app/views/mobility_devices/edit.haml
@@ -1,0 +1,5 @@
+%h1 Editing #{@device.device}
+
+= render 'form'
+
+= link_to 'Back', mobility_devices_url

--- a/app/views/mobility_devices/index.haml
+++ b/app/views/mobility_devices/index.haml
@@ -1,0 +1,21 @@
+%h1 Mobility Devices
+%table#mobility-devices
+  %thead
+    %tr
+      %th Device
+      %th Needs Longer Rides?
+      %th
+      %th
+  %tbody
+    - if @devices.present?
+      - @devices.each do |device|
+        %tr
+          %td= device.device
+          %td= yes_no_image device.needs_longer_rides?
+          %td= link_to 'Edit', edit_mobility_device_url(device)
+          %td= button_to 'Destroy', device, method: :delete
+    - else
+      %tr
+        %td{colspan: 4} No devices to show.
+%br
+= link_to 'New mobility device', new_mobility_device_url

--- a/app/views/mobility_devices/new.haml
+++ b/app/views/mobility_devices/new.haml
@@ -1,0 +1,5 @@
+%h1 New mobility device
+
+= render 'form'
+
+= link_to 'Back', mobility_devices_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,11 @@ Rails.application.routes.draw do
   else root 'passengers#index'
   end
 
-  resources :users, except: :show
-  resources :passengers
   resources :doctors_notes
   resources :log, except: %i[edit new show]
+  resources :mobility_devices, except: :show
+  resources :passengers
+  resources :users, except: :show
 
   unless Rails.env.production?
     get  'sessions/dev_login',

--- a/db/migrate/20170829130516_add_needs_longer_rides_to_mobility_devices.rb
+++ b/db/migrate/20170829130516_add_needs_longer_rides_to_mobility_devices.rb
@@ -1,0 +1,6 @@
+class AddNeedsLongerRidesToMobilityDevices < ActiveRecord::Migration[5.1]
+  def change
+    add_column :mobility_devices, :needs_longer_rides, :boolean,
+               default: false, null: false
+  end
+end

--- a/db/migrate/20170829132804_remove_lift_ramp_from_mobility_devices.rb
+++ b/db/migrate/20170829132804_remove_lift_ramp_from_mobility_devices.rb
@@ -1,0 +1,5 @@
+class RemoveLiftRampFromMobilityDevices < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :mobility_devices, :lift_ramp, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823143949) do
+ActiveRecord::Schema.define(version: 20170829130516) do
 
   create_table "doctors_notes", force: :cascade do |t|
     t.integer "passenger_id"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20170823143949) do
     t.boolean "lift_ramp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "needs_longer_rides", default: false, null: false
   end
 
   create_table "passengers", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170829130516) do
+ActiveRecord::Schema.define(version: 20170829132804) do
 
   create_table "doctors_notes", force: :cascade do |t|
     t.integer "passenger_id"
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 20170829130516) do
 
   create_table "mobility_devices", force: :cascade do |t|
     t.string "device"
-    t.boolean "lift_ramp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "needs_longer_rides", default: false, null: false


### PR DESCRIPTION
Closes #47.

Renamed (effectively) `lift_ramp` to `needs_longer_rides` for clarity.

<img width="1439" alt="screen shot 2017-08-29 at 9 39 05 am" src="https://user-images.githubusercontent.com/3988134/29823941-2362c6a4-8c9e-11e7-8be3-1887d005275c.png">
<img width="1440" alt="screen shot 2017-08-29 at 9 39 11 am" src="https://user-images.githubusercontent.com/3988134/29823942-23776276-8c9e-11e7-8933-a3676fe2ad63.png">
