### PR TITLE
Don't require a SPIRE

### DIFF
--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -9,7 +9,8 @@ class Passenger < ApplicationRecord
   validates :status, inclusion: { in: STATUSES, allow_blank: true }
   validates :spire,
             format: { with: /\A\d{8}@umass.edu\z/,
-                      message: 'must be 8 digits followed by @umass.edu' }
+                      message: 'must be 8 digits followed by @umass.edu',
+                      allow_blank: true }
 
   belongs_to :registerer, foreign_key: :registered_by, class_name: 'User',
                           optional: true

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 97.14
+    "covered_percent": 97.16
   }
 }

--- a/spec/models/passenger_spec.rb
+++ b/spec/models/passenger_spec.rb
@@ -29,6 +29,13 @@ describe Passenger do
     end
   end
 
+  describe 'not having a SPIRE' do
+    it 'is valid' do
+      passenger = build :passenger, spire: ''
+      expect(passenger).to be_valid
+    end
+  end
+
   describe 'self.deactivate_expired_doc_note' do
     it 'deactivates the expired passenger' do
       create :doctors_note, passenger: @passenger,


### PR DESCRIPTION
We effectively were, by enforcing this format validation on blank strings.