### PR TITLE
Disable perm. passenger fields on page load 

### DIFF
--- a/app/assets/javascripts/input_disable.js
+++ b/app/assets/javascripts/input_disable.js
@@ -3,6 +3,7 @@ $(document).on('turbolinks:load', function(){
     var expirationField = $('.doctors_note_expiration_date');
     if($(this).is(':checked')){
       expirationField.prop('disabled', true);
+      expirationField.prop("checked", false);
       expirationField.val('');
     }
     else expirationField.prop('disabled', false);

--- a/app/assets/javascripts/input_disable.js
+++ b/app/assets/javascripts/input_disable.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load', function(){
   $('#passenger_permanent').change(function(){
-    var expirationField = $('#doctors_note_expiration_date');
+    var expirationField = $('.doctors_note_expiration_date');
     if($(this).is(':checked')){
       expirationField.prop('disabled', true);
       expirationField.val('');

--- a/app/assets/stylesheets/doc_note.scss
+++ b/app/assets/stylesheets/doc_note.scss
@@ -1,3 +1,0 @@
-.hide_view {
-  display: none;
-}

--- a/app/assets/stylesheets/passengers.scss
+++ b/app/assets/stylesheets/passengers.scss
@@ -124,3 +124,7 @@ div {
     list-style: square;
   }
 }
+
+.hide_view {
+  display: none;
+}

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -41,7 +41,7 @@ class PassengersController < ApplicationController
 
   def update
     @passenger.assign_attributes passenger_params
-    if @passenger.doctors_note.override_until_changed? && @current_user.admin?
+    if @passenger.doctors_note.present? && @passenger.doctors_note.override_until_changed? && @current_user.admin?
       @passenger.doctors_note.assign_attributes overridden_by: @current_user
     end
     if @passenger.save

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -41,7 +41,7 @@ class PassengersController < ApplicationController
 
   def update
     @passenger.assign_attributes passenger_params
-    if @passenger.doctors_note.present? && @passenger.doctors_note.override_until_changed? && @current_user.admin?
+    if @current_user.admin? && @passenger.doctors_note.try(:override_until_changed?)
       @passenger.doctors_note.assign_attributes overridden_by: @current_user
     end
     if @passenger.save

--- a/app/helpers/passengers_helper.rb
+++ b/app/helpers/passengers_helper.rb
@@ -27,7 +27,7 @@ module PassengersHelper
     end
   end
 
-  def passengers_form_class
+  def hide_form_class
     'hide_view' unless @doctors_note.override_expiration?
   end
 end

--- a/app/views/passengers/_form.html.haml
+++ b/app/views/passengers/_form.html.haml
@@ -54,17 +54,17 @@
     .field
       = d.label :expiration_date
       = d.text_field :expiration_date,
-        class: 'datepicker', id: :doctors_note_expiration_date
+        class: 'datepicker doctors_note_expiration_date', disabled: @passenger.permanent?
     - if @current_user.admin?
       .field
         = d.label :override_expiration
         = d.check_box :override_expiration,
           id: 'active-checkbox'
       - if @doctors_note.present?
-        .field#slide-date{class: passengers_form_class}
+        .field#slide-date{class: hide_form_class}
           = d.label :override_until
           = d.text_field :override_until,
-            class: 'datepicker'
+            class: 'datepicker doctors_note_expiration_date', disabled: @passenger.permanent?
   .field
     = form.label :note
     = form.text_area :note, rows: 20, cols: 100

--- a/app/views/passengers/_form.html.haml
+++ b/app/views/passengers/_form.html.haml
@@ -59,12 +59,13 @@
       .field
         = d.label :override_expiration
         = d.check_box :override_expiration,
-          id: 'active-checkbox'
+          id: 'active-checkbox', class: 'doctors_note_expiration_date',
+           disabled: @passenger.permanent?
       - if @doctors_note.present?
         .field#slide-date{class: hide_form_class}
           = d.label :override_until
           = d.text_field :override_until,
-            class: 'datepicker doctors_note_expiration_date', disabled: @passenger.permanent?
+            class: 'datepicker doctors_note_expiration_date'
   .field
     = form.label :note
     = form.text_area :note, rows: 20, cols: 100

--- a/spec/features/passenger_management_spec.rb
+++ b/spec/features/passenger_management_spec.rb
@@ -16,7 +16,7 @@ feature 'Passenger Management' do
       fill_in('passenger[name]', with: 'Foo Bar')
       fill_in('passenger[email]', with: 'foobar@invalid.com')
       fill_in('passenger[spire]', with: '12345678@umass.edu')
-      fill_in('doctors_note_expiration_date', with: date)
+      fill_in('passenger[doctors_note_attributes][expiration_date]', with: date)
       click_button('Submit')
       expect(page).to have_text('Passenger was successfully created.')
     end
@@ -65,7 +65,7 @@ feature 'Passenger Management' do
       click_link 'Add New Passenger'
       fill_in('passenger[name]', with: 'Foo Bar')
       fill_in('passenger[email]', with: 'foobar@invalid.com')
-      fill_in('doctors_note_expiration_date', with: date)
+      fill_in('passenger[doctors_note_attributes][expiration_date]', with: date)
       fill_in('passenger[spire]', with: '12345678@umass.edu')
       click_button('Submit')
       expect(page).to have_text('Passenger was successfully created.')


### PR DESCRIPTION
This PR also adds a check for the presence of a passengers note before updating passenger_note_params.