### PR TITLE
Use utf8mb4 as the default encoding

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -2,6 +2,8 @@ default: &default
   adapter: mysql2
   pool: 5
   timeout: 5000
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
 
 development:
   <<: *default

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20170913210806) do
 
-  create_table "doctors_notes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "doctors_notes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "passenger_id"
     t.date "expiration_date"
     t.integer "overridden_by_id"
@@ -22,21 +22,21 @@ ActiveRecord::Schema.define(version: 20170913210806) do
     t.boolean "override_expiration"
   end
 
-  create_table "log_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "log_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.integer "user_id"
     t.text "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mobility_devices", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "mobility_devices", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "needs_longer_rides", default: false, null: false
   end
 
-  create_table "passengers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "passengers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name"
     t.string "email"
     t.string "address"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20170913210806) do
     t.boolean "has_brochure"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name"
     t.string "spire"
     t.boolean "active"


### PR DESCRIPTION
utf8 is garbage. 

See https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434