### PR TITLE
Typo in production config

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-remote_user = Net::SSH::Config.for('af-transit-app3.admin.umass.edu')[:user] || ENV['USER']
+remote_user = Net::SSH::Config.for('af-transit-app4.admin.umass.edu')[:user] || ENV['USER']
 server 'af-transit-app4.admin.umass.edu',
        roles: %w[app db web],
        user: remote_user,


### PR DESCRIPTION
Uses configuration for `app3` to connect to `app4`.