### PR TITLE
Xpath removal

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 62.97
+    "covered_percent": 63.41
   }
 }

--- a/spec/system/passenger_management_spec.rb
+++ b/spec/system/passenger_management_spec.rb
@@ -63,8 +63,9 @@ RSpec.describe 'Passenger Management', js: true do
     context 'deleting an existing passenger successfully' do
       it 'deletes the passenger' do
         visit passengers_path
-        click_button 'Delete'
-        page.driver.browser.switch_to.alert.accept
+        page.accept_confirm 'Are you sure?' do
+          click_button 'Delete'
+        end
         expect(page).to have_text 'Passenger successfully destroyed.'
       end
     end

--- a/spec/system/user_management_spec.rb
+++ b/spec/system/user_management_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'User Management', js: true do
     end
     it 'puts the errors in the flash' do
       visit users_url
-      # Find destroy link by href because there are 2 users by necessity.
-      # Although you definitely _can_ delete yourself.
-      find(:xpath, "//a[@href='/users/#{@user.id}']").click
-      page.driver.browser.switch_to.alert.accept
+      # Click the 'destroy' link in the user's row
+      page.accept_confirm 'Are you sure?' do
+        within('tr', text: @user.name) { click_on 'Destroy' }
+      end
       expect(page).to have_text(
         'Cannot delete record because dependent log entries exist'
       )
@@ -25,8 +25,9 @@ RSpec.describe 'User Management', js: true do
   context 'deleting a user successfully' do
     it 'deletes the user and says it did' do
       visit users_url
-      find(:xpath, "//a[@href='/users/#{@user.id}']").click
-      page.driver.browser.switch_to.alert.accept
+      page.accept_confirm 'Are you sure?' do
+        within('tr', text: @user.name) { click_on 'Destroy' }
+      end
       expect(page).to have_text(
         'User successfully destroyed'
       )
@@ -35,7 +36,7 @@ RSpec.describe 'User Management', js: true do
   context 'editing an existing user successfully' do
     it 'updates the user' do
       visit users_path
-      find(:xpath, "//a[@href='/users/#{@user.id}/edit']").click
+      within('tr', text: @user.name) { click_on 'Edit' }
       fill_in 'Name', with: 'Bar Foo'
       click_button 'Save'
       expect(page).to have_text 'User successfully updated'
@@ -44,7 +45,7 @@ RSpec.describe 'User Management', js: true do
   context 'editing an existing user unsuccessfully' do
     it 'puts the error in the flash' do
       visit users_path
-      find(:xpath, "//a[@href='/users/#{@user.id}/edit']").click
+      within('tr', text: @user.name) { click_on 'Edit' }
       fill_in 'Spire', with: 'not a valid spire'
       click_button 'Save'
       expect(page).to have_text 'Spire must be 8 digits followed by @umass.edu'


### PR DESCRIPTION
These tests failed when I decided destroying a user should be a button rather than a link.

In fixing it, I realized that the xpath notation is nearly impenetrable to me, and it doesn't really reflect how a "real person" would find what thing to click on. Instead of finding by `href`, let's find the "Destroy" that's in the same row as the user's name.