### PR TITLE
Just tell DataTables it's a date

### DIFF
--- a/app/helpers/passengers_helper.rb
+++ b/app/helpers/passengers_helper.rb
@@ -14,8 +14,4 @@ module PassengersHelper
       'expired'
     end
   end
-
-  def sortable_date(note)
-    note.expiration_date.strftime('%Y%m%d') if note.present?
-  end
 end

--- a/app/views/passengers/archived.html.haml
+++ b/app/views/passengers/archived.html.haml
@@ -8,7 +8,7 @@
         %th Email
         %th Phone
         %th Permanent
-        %th Doc's Note Expires
+        %th{data: {type: 'date'}} Doc's Note Expires
         %th{data: {orderable: 'false'}}
         %th{data: {orderable: 'false'}}
         %th{data: {orderable: 'false'}}

--- a/app/views/passengers/index.haml
+++ b/app/views/passengers/index.haml
@@ -29,7 +29,7 @@
         %th Needs longer rides?
         %th Phone
         %th.permanent.text-center Permanent
-        %th.text-center Rides Expire
+        %th.text-center{data: {type: 'date'}} Rides Expire
         %th{data: {orderable: 'false'}}
         %th{data: {orderable: 'false'}}
         - if @current_user.admin?
@@ -44,7 +44,7 @@
           %td= passenger.phone
           - permanent_data = {sort: passenger.permanent_or_temporary, filter: passenger.permanent_or_temporary}
           %td.text-center{data: permanent_data}= checkmark_glyph passenger.permanent?
-          %td.text-center{data: {sort: sortable_date(passenger.doctors_note)}}=passenger.rides_expire.try(:strftime, '%m/%d/%Y')
+          %td.text-center= passenger.rides_expire.try(:strftime, '%m/%d/%Y')
           %td= link_to 'View', passenger
           %td= link_to 'Edit', edit_passenger_path(passenger)
           - if @current_user.admin?

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 64.1
+    "covered_percent": 63.96
   }
 }


### PR DESCRIPTION
Closes #188.

In looking into it, it seems like there are cases where DataTables thinks the data source is something other than the DOM (?) A fix I found was to explicitly put `data-type="@data-sort"` on the header. But... if we're going to do that, why not just use `data-type="date"`? Sorts like a dream.