### PR TITLE
Make the glyphs a bit more accessible

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,9 +7,16 @@ module ApplicationHelper
     link_to text, url, class: button_classes
   end
 
-  def checkmark_glyph(value, yes: 'fa-check', no: 'fa-times')
-    icon_class = value ? ['yes-glyph', yes] : ['no-glyph', no]
-    content_tag :span, nil, class: icon_class << 'fas'
+  def checkmark_glyph(value, options = {})
+    options.reverse_merge!({yes: 'fa-check', no: 'fa-times'})
+    word = value ? 'yes' : 'no'
+
+    capture do
+      concat content_tag :span, nil,
+        class: ['fas', "#{word}-glyph", options.fetch(word.to_sym)],
+        aria: {hidden: true}, title: word
+      concat content_tag :span, word, class: 'sr-only'
+    end
   end
 
   def list_messages(messages)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
     capture do
       concat content_tag :span, nil,
         class: ['fas', "#{word}-glyph", options.fetch(word.to_sym)],
-        aria: {hidden: true}, title: word
+        aria: {hidden: 'true'}, title: word
       concat content_tag :span, word, class: 'sr-only'
     end
   end

--- a/app/views/passengers/index.haml
+++ b/app/views/passengers/index.haml
@@ -40,10 +40,9 @@
         %tr{class: passengers_table_row_class(passenger)}
           %td= passenger.name
           %td= passenger.mobility_device.try(:name)
-          %td{data: {sort: passenger.needs_longer_rides?.to_s}}= checkmark_glyph(passenger.needs_longer_rides?, no: '')
+          %td= checkmark_glyph(passenger.needs_longer_rides?, no: '')
           %td= passenger.phone
-          - permanent_data = {sort: passenger.permanent_or_temporary, filter: passenger.permanent_or_temporary}
-          %td.text-center{data: permanent_data}= checkmark_glyph passenger.permanent?
+          %td.text-center{data: {filter: passenger.permanent_or_temporary}}= checkmark_glyph passenger.permanent?
           %td.text-center{data: {sort: sortable_date(passenger.doctors_note)}}=passenger.rides_expire.try(:strftime, '%m/%d/%Y')
           %td= link_to 'View', passenger
           %td= link_to 'Edit', edit_passenger_path(passenger)


### PR DESCRIPTION
by providing some screen-reader-only content.  As a side-effect, DataTables can sort by said content, making the `data-sort` attribute no longer needed.