### PR TITLE
Put a pseudo-anonymous signature in the GH issues

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -9,6 +9,7 @@ class FeedbackController < ApplicationController
 
   def create
     @feedback = Feedback.new(feedback_params)
+    @feedback.user = @current_user
     unless @feedback.valid?
       flash.now[:danger] = @feedback.errors.full_messages
       render(:new) && return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[destroy edit update]
+  before_action :set_user, except: %i[index new create]
 
   def index
     @users = User.order(:name)

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -5,7 +5,7 @@ require 'mock_github_client'
 class Feedback
   include ActiveModel::Model
 
-  attr_accessor :title, :description, :category, :issue
+  attr_accessor :title, :description, :category, :issue, :user
 
   CATEGORIES = %w[bug enhancement addition].freeze
   DEFAULT_CATEGORIES = %w[unconfirmed].freeze
@@ -22,8 +22,10 @@ class Feedback
   end
 
   def submit!
-    @issue =
-      client.create_issue Feedback.repo, title, description, labels: labels
+    @issue = client.create_issue Feedback.repo,
+                                 title,
+                                 signed_description,
+                                 labels: labels
   end
 
   def load(issue_number)
@@ -47,5 +49,11 @@ class Feedback
   def labels
     categories = Feedback::DEFAULT_CATEGORIES + [category]
     categories.join(',')
+  end
+
+  def signed_description
+    return description unless user.present?
+
+    "#{description}\n\n[#{user.id}](#{user.url})"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,9 @@ class User < ApplicationRecord
   def dispatcher?
     !admin?
   end
+
+  def url
+    Rails.application.routes.url_helpers.user_url self,
+      Rails.application.config.action_mailer.default_url_options
+  end
 end

--- a/app/views/feedback/index.haml
+++ b/app/views/feedback/index.haml
@@ -1,5 +1,5 @@
 %p
-  Previously reported feedback can be viewed on
+  Previously reported feedback is publicly accessible on
   = succeed '.' do
     = link_to 'GitHub', github_url
 %p

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -1,0 +1,12 @@
+%h1= @user.name
+%p
+  %b Spire:
+  = @user.spire
+%p
+  %b Active:
+  = checkmark_glyph @user.active?
+%p
+  %b Admin:
+  = checkmark_glyph @user.admin?
+= link_to 'Edit', edit_user_path
+= link_to 'Back', users_path

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: 3000
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,6 +76,11 @@ Rails.application.configure do
       port: 25
   }
 
+  config.action_mailer.default_url_options = {
+    host: 'st-pax.admin.umass.edu',
+    protocol: 'https'
+  }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back
   # to the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = {only_path: true}
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       post :toggle_archive
     end
   end
-  resources :users, except: :show
+  resources :users
 
   unless Rails.env.production?
     get  'sessions/dev_login',

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 63.96
+    "covered_percent": 64.59
   }
 }

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Feedback do
   let(:feedback) { build :feedback }
 
   describe '#submit!' do
+    let(:sig_pattern) { /^\[\d+\]\([^)]+\)$/ }
     let(:call) { feedback.submit! }
     before :each do
       allow(feedback).to receive(:client).and_return(client)
@@ -20,6 +21,14 @@ RSpec.describe Feedback do
         feedback.description,
         hash_including(labels: /#{feedback.category}/)
       )
+      call
+    end
+
+    it 'signs the feedback if the user is set' do
+      expect(client).to receive(:create_issue).with(
+        anything, anything, sig_pattern, any_args
+      )
+      feedback.user = create :user
       call
     end
   end

--- a/spec/system/feedback_submission_spec.rb
+++ b/spec/system/feedback_submission_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Feedback Submission' do
   let(:title) { 'The site is broken' }
   let(:client) { MockGithubClient.new(logger: Logger.new(nil)) }
   let(:issue) { client.issue('repo', -999) }
+  let(:sig_pattern) { /^\[\d+\]\([^)]+\)$/ }
 
   before :each do
     allow(MockGithubClient).to receive(:new).and_return client
@@ -24,7 +25,8 @@ RSpec.describe 'Feedback Submission' do
 
   it 'submits the feedback' do
     expect(client).to receive(:create_issue)
-      .with(anything, title, '', hash_including(:labels)).and_call_original
+      .with(anything, title, sig_pattern, hash_including(:labels))
+      .and_call_original
 
     fill_in 'Title', with: title
     click_on 'Submit'
@@ -41,7 +43,8 @@ RSpec.describe 'Feedback Submission' do
 
   it 'displays the GitHub content if submission succeeds' do
     allow(client).to receive(:create_issue)
-      .with(anything, title, '', hash_including(:labels)).and_call_original
+      .with(anything, title, sig_pattern, hash_including(:labels))
+      .and_call_original
 
     fill_in 'Title', with: title
     click_on 'Submit'


### PR DESCRIPTION
People with logins to the site can click the link to see who submitted the feedback. Everyone else will have to use the Rails console.