### PR TITLE
this has been bothering me.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,8 +19,10 @@ module SeedCreator
     end
 
     def create_passengers
-      create_list :passenger, 20, :permanent
-      create_list :passenger, 20, :temporary, :with_note
+      create_list :passenger, 10, :permanent
+      create_list :passenger, 10, :permanent, :with_mobility_device
+      create_list :passenger, 10, :temporary, :with_note
+      create_list :passenger, 10, :temporary, :with_note, :with_mobility_device
 
       create_list :passenger, 5, :temporary, :expired_within_grace_period
       create_list :passenger, 5, :temporary, :expiring_soon

--- a/spec/factories/passengers.rb
+++ b/spec/factories/passengers.rb
@@ -6,10 +6,13 @@ FactoryBot.define do
     address { FFaker::Address.street_address }
     email { FFaker::Internet.email }
     phone { FFaker::PhoneNumber.short_phone_number }
-    mobility_device { MobilityDevice.all.sample }
     sequence(:spire) { |n| n.to_s.rjust(8, '0') + '@umass.edu' }
     active_status { 'active' }
     registration_date { Time.zone.today }
+
+    trait :with_mobility_device do
+      mobility_device { MobilityDevice.all.sample }
+    end
 
     trait :temporary do
       permanent { false }
@@ -21,9 +24,7 @@ FactoryBot.define do
     end
 
     trait :inactive do
-      after :create do |passenger|
-        create :doctors_note, :expired, passenger: passenger
-      end
+      association :doctors_note, :expired
     end
 
     trait :no_note do
@@ -31,21 +32,15 @@ FactoryBot.define do
     end
 
     trait :with_note do
-      after :create do |passenger|
-        create :doctors_note, passenger: passenger
-      end
+      association :doctors_note
     end
 
     trait :expired_within_grace_period do
-      after :create do |passenger|
-        create :doctors_note, :expired_within_grace_period, passenger: passenger
-      end
+      association :doctors_note, :expired_within_grace_period
     end
 
     trait :expiring_soon do
-      after :create do |passenger|
-        create :doctors_note, :expiring_soon, passenger: passenger
-      end
+      association :doctors_note, :expiring_soon
     end
   end
 end


### PR DESCRIPTION
you don't have to do after_create hooks to have an association with
an object. and let's keep non-essential associations or attributes
to traits.