### PR TITLE
Use after_create blocks to associate certain objects in FactoryBot

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,13 +21,12 @@ module SeedCreator
     def create_passengers
       create_list :passenger, 10, :permanent
       create_list :passenger, 10, :permanent, :with_mobility_device
-      create_list :passenger, 10, :temporary, :with_note
-      create_list :passenger, 10, :temporary, :with_note, :with_mobility_device
-
-      create_list :passenger, 5, :temporary, :expired_within_grace_period
-      create_list :passenger, 5, :temporary, :expiring_soon
-      create_list :passenger, 5, :temporary, :inactive
-      create_list :passenger, 5, :temporary, :no_note
+      create_list :temporary_passenger, 10, :with_note
+      create_list :temporary_passenger, 10, :with_note, :with_mobility_device
+      create_list :temporary_passenger, 5, :expired_within_grace_period
+      create_list :temporary_passenger, 5, :expiring_soon
+      create_list :temporary_passenger, 5, :inactive
+      create_list :temporary_passenger, 5, :no_note
     end
 
     def create_dispatch_logs

--- a/spec/factories/eligibility_verifications.rb
+++ b/spec/factories/eligibility_verifications.rb
@@ -2,12 +2,12 @@
 
 FactoryBot.define do
   factory :eligibility_verification do
+    expiration_date { 1.month.from_now }
     passenger
   end
 
-  trait :for_temporary_passenger do
-    expiration_date { 1.month.from_now }
-    verifying_agency
+  trait :with_agency do
+    association :verifying_agency
   end
 
   trait :expired_within_grace_period do

--- a/spec/factories/passengers.rb
+++ b/spec/factories/passengers.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     email { FFaker::Internet.email }
     phone { FFaker::PhoneNumber.short_phone_number }
     sequence(:spire) { |n| n.to_s.rjust(8, '0') + '@umass.edu' }
-    # active_status { 'active' }
 
     factory :temporary_passenger do
       permanent { false }

--- a/spec/helpers/passengers_helper_spec.rb
+++ b/spec/helpers/passengers_helper_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe PassengersHelper do
   describe 'passengers_table_row_class' do
     before :each do
-      @passenger = create :passenger, :temporary
+      @passenger = create :temporary_passenger, :with_note
       @verification = @passenger.eligibility_verification
     end
     context 'will expire within warning period' do
@@ -31,7 +31,7 @@ RSpec.describe PassengersHelper do
     end
     context 'the passenger needs a doctors note' do
       it 'returns the correct class' do
-        @passenger = create :passenger, :no_note
+        @passenger = create :temporary_passenger, :no_note
         expect(helper.passengers_table_row_class(@passenger)).to eql 'needs-note'
       end
     end

--- a/spec/models/passenger_spec.rb
+++ b/spec/models/passenger_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Passenger do
   before :each do
-    @passenger = create :passenger, :temporary
+    @passenger = create :temporary_passenger, :with_note
   end
 
   describe 'expiration_display' do

--- a/spec/system/passenger_archive_spec.rb
+++ b/spec/system/passenger_archive_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Archived Passenger Management' do
     context 'having filled in the correct data' do
       before :each do
         create :eligibility_verification,
-          :for_temporary_passenger,
+          :with_agency,
           passenger: @passenger
       end
       it 'successfully reactivates the passenger' do

--- a/spec/system/passenger_filters_spec.rb
+++ b/spec/system/passenger_filters_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Passenger Filters' do
 
   context 'html view', js: true do
     it 'allows filtering by permanent status' do
-      create :passenger, :temporary, name: 'Gary Stue'
+      create :temporary_passenger, name: 'Gary Stue'
       create :passenger, :permanent, name: 'Mary Sue'
       visit passengers_url
       choose 'Permanent'
@@ -20,7 +20,7 @@ RSpec.describe 'Passenger Filters' do
 
     it 'allows filtering by temporary' do
       create :passenger, :permanent, name: 'Mary Sue'
-      create :passenger, :temporary, name: 'Gary Stue'
+      create :temporary_passenger, name: 'Gary Stue'
       visit passengers_url
       choose 'Temporary'
       expect(page).to have_selector 'table#passengers tbody tr', count: 1
@@ -29,7 +29,7 @@ RSpec.describe 'Passenger Filters' do
     end
 
     it 'allows filtering by everyone' do
-      create :passenger, :temporary, name: 'Gary Stue'
+      create :temporary_passenger, name: 'Gary Stue'
       create :passenger, :permanent, name: 'Mary Sue'
       visit passengers_url
       choose 'All'

--- a/spec/system/passenger_key_spec.rb
+++ b/spec/system/passenger_key_spec.rb
@@ -8,21 +8,21 @@ RSpec.describe 'Passenger Keys' do
   end
   context 'doctors note will expire in a week' do
     it 'gives the correct class to the row' do
-      create :passenger, :expiring_soon
+      create :temporary_passenger, :expiring_soon
       visit passengers_url
       expect(page).to have_css('tr.expires-soon')
     end
   end
   context 'doctors note is recently expired' do
     it 'gives the correct class to the row' do
-      create :passenger, :expired_within_grace_period
+      create :temporary_passenger, :expired_within_grace_period
       visit passengers_url
       expect(page).to have_css('tr.needs-note')
     end
   end
   context 'No Note' do
     it 'gives the correct class to the row' do
-      create :passenger, :no_note
+      create :temporary_passenger, :no_note
       visit passengers_url
       expect(page).to have_css('tr.needs-note')
     end


### PR DESCRIPTION
For example, if passenger has an association :eligibility_verification
and eligibility verification has an association with passenger,
creating a passenger with an eligibility verification will create a
second passenger.
Tests pass and objects are properly related to each other with no
extras.