### PR TITLE
Backend mailing code written, placeholder email template given

### DIFF
--- a/app/mailers/passenger_mailer.rb
+++ b/app/mailers/passenger_mailer.rb
@@ -1,6 +1,6 @@
 class PassengerMailer < ApplicationMailer
   def notify_archived(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'ST Account Archived'
+    mail to: @passenger.email, subject: 'Special Transit Account Archived'
   end
 end

--- a/app/mailers/passenger_mailer.rb
+++ b/app/mailers/passenger_mailer.rb
@@ -1,0 +1,6 @@
+class PassengerMailer < ApplicationMailer
+  def notify_archived(passenger)
+    @passenger = passenger
+    mail to: @passenger.email, subject: 'ST Account Archived'
+  end
+end

--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -77,7 +77,9 @@ class Passenger < ApplicationRecord
       save
     else
       # skip validations on archival
-      update_attribute(:active_status, 'archived')
+      success = update_attribute(:active_status, 'archived')
+      PassengerMailer.notify_archived(self).deliver_now if success
+      success
     end
   end
 

--- a/app/views/passenger_mailer/notify_archived.haml
+++ b/app/views/passenger_mailer/notify_archived.haml
@@ -1,3 +1,4 @@
-#{@passenger.name},
+Dear #{@passenger.name},
 
-Your account at Special Transit has been archived.
+Our records indicate that you only needed rides until #{Time.now.strftime("%m/%d/%Y")}, so we are archiving your account.
+If you do still need our service feel free to call us at (413) 545-2086.

--- a/app/views/passenger_mailer/notify_archived.haml
+++ b/app/views/passenger_mailer/notify_archived.haml
@@ -1,0 +1,3 @@
+#{@passenger.name},
+
+Your account at Special Transit has been archived.


### PR DESCRIPTION
closes #156

Added automatic emailing behavior when a passenger is archived.

As it stands the mailer is specific to passenger mail. I chose this over a more general class; in my mind it allows for more organization/scalability in the future with the downsides mainly being some unnecessary categorization.

The email is sent from the Passenger model, within the toggle_archived_status method. I couldn't really find an elegant way to implement sending the email while preserving the original return value. I took the route of making the changes uglier in favor of readability.
