### PR TITLE
Creating new passenger now correctly records the registerer

### DIFF
--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -50,7 +50,7 @@ class PassengersController < ApplicationController
 
   def create
     @passenger = Passenger.new(passenger_params)
-    @passenger.registered_by = @current_user
+    @passenger.registerer = @current_user
     if @passenger.save
       flash[:success] = 'Passenger successfully created.'
       redirect_to @passenger

--- a/app/views/passengers/show.haml
+++ b/app/views/passengers/show.haml
@@ -35,7 +35,7 @@
     = @passenger.rides_expire.strftime('%m/%d/%Y')
 %p
   %b Registering Dispatcher:
-  = @passenger&.registerer&.name
+  = @passenger.registerer&.name
 %p
   %b Registration Date:
   = @passenger.registration_date

--- a/app/views/passengers/show.haml
+++ b/app/views/passengers/show.haml
@@ -35,7 +35,7 @@
     = @passenger.rides_expire.strftime('%m/%d/%Y')
 %p
   %b Registering Dispatcher:
-  = @passenger.registerer ? @passenger.registerer.name : 'Unknown'
+  = @passenger&.registerer&.name
 %p
   %b Registration Date:
   = @passenger.registration_date

--- a/app/views/passengers/show.haml
+++ b/app/views/passengers/show.haml
@@ -35,7 +35,7 @@
     = @passenger.rides_expire.strftime('%m/%d/%Y')
 %p
   %b Registering Dispatcher:
-  = @passenger.registerer || 'Unknown'
+  = @passenger.registerer ? @passenger.registerer.name : 'Unknown'
 %p
   %b Registration Date:
   = @passenger.registration_date

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 67.04
+    "covered_percent": 68.32
   }
 }


### PR DESCRIPTION
Closes #209 

As it was, the controller method was trying to assign the registerer by assigning `.registered_by` as the user's ActiveRecord object, when `.registered_by` is actually the foreign_key id column. 

As it was, displaying a passenger also trying to display the object string format (<ActiveRecord: ...>. Now it correctly displays the dispatcher's name.