### PR TITLE
Fixed error handling for dispatch logs

### DIFF
--- a/app/controllers/log_controller.rb
+++ b/app/controllers/log_controller.rb
@@ -7,11 +7,10 @@ class LogController < ApplicationController
     @entry = LogEntry.new entry_params.merge(user: @current_user)
     if @entry.save
       flash[:success] = 'Log entry was successfully created.'
-      redirect_to log_index_path
     else
       flash[:danger] = @entry.errors.full_messages
-      render :index
     end
+    redirect_to log_index_path
   end
 
   def destroy
@@ -32,11 +31,10 @@ class LogController < ApplicationController
   def update
     if @entry.update entry_params
       flash[:success] = 'Log entry was successfully changed.'
-      redirect_to log_index_path
     else
       flash[:danger] = @entry.errors.full_messages
-      render log_index_path
     end
+    redirect_to log_index_path
   end
 
   private

--- a/app/views/log/index.haml
+++ b/app/views/log/index.haml
@@ -19,7 +19,7 @@
           - if @current_user.can_modify? entry
             .edit-form
               = bootstrap_form_with namespace: entry.id, model: entry, url: log_url(entry) do |f|
-                = f.text_area :text, rows: 8, hide_label: true
+                = f.text_area :text, required: true, rows: 8, hide_label: true
                 = f.primary 'Change log entry'
         .actions.col-xl-1.form-inline
           - if @current_user.can_modify? entry

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 68.32
+    "covered_percent": 68.58
   }
 }


### PR DESCRIPTION
Closes #175 

The server was 500ing due to some improper render calls on error, which I just combined with the success redirect since they serve the same purpose.

Also required the edit text box to have text on an html level. Now a user shouldn't be able to submit a bad request and if a bad request somehow happens, it will flash an error and not silently fail.