### PR TITLE
Another date fix

### DIFF
--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -79,7 +79,7 @@ class Passenger < ApplicationRecord
     end
     return 3.business_days.since(registration_date) if persisted?
 
-    3.business_days.from_now
+    3.business_days.from_now.to_date
   end
 
   def temporary?

--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -77,9 +77,9 @@ class Passenger < ApplicationRecord
     if eligibility_verification&.expiration_date.present?
       return 3.business_days.after(eligibility_verification.expiration_date)
     end
-    return 3.business_days.since(registration_date) if persisted?
+    return 3.business_days.after(registration_date) if persisted?
 
-    3.business_days.from_now.to_date
+    3.business_days.after(Time.zone.today)
   end
 
   def temporary?

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 68.94
+    "covered_percent": 73.56
   }
 }

--- a/spec/models/passenger_spec.rb
+++ b/spec/models/passenger_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Passenger do
       end
       context 'passenger is a new record' do
         it 'returns 3 days from now' do
-          expect(Passenger.new.rides_expire).to eq 3.business_days.from_now
+          expect(Passenger.new.rides_expire).to eq 3.business_days.from_now.to_date
         end
       end
     end


### PR DESCRIPTION
As soon as the passenger is saved, their registration _date_ will be assigned to be `Time.zone.today`, so it doesn't make sense for it to be a date and time before the passenger is saved.

Also, it should be 3 business days after the beginning of today, not the beginning of the day 3 business days from now.