### PR TITLE
Fix occasional passenger spec failure

### DIFF
--- a/spec/models/passenger_spec.rb
+++ b/spec/models/passenger_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Passenger do
       end
       context 'passenger is a new record' do
         it 'returns 3 days from now' do
-          expect(Passenger.new.rides_expire).to eq 3.business_days.from_now.to_date
+          expect(Passenger.new.rides_expire).to eq 3.business_days.after(Time.zone.today)
         end
       end
     end


### PR DESCRIPTION
This test occasionally fails depending on when it's run. I'm not exactly sure why but it seems `3.business_days.from_now()`  calculates the resulting `ActiveSupport::TimeWithZone` from the wrong time zone.

![image](https://user-images.githubusercontent.com/26842354/94509762-1109f000-01e3-11eb-9bff-7505b269eb39.png)

In the model:
```ruby
def rides_expire
  return if permanent?

  if eligibility_verification&.expiration_date.present?
    return 3.business_days.after(eligibility_verification.expiration_date)
  end
  return 3.business_days.after(registration_date) if persisted?

  3.business_days.after(Time.zone.today)
end
```


