### PR TITLE
Allow git repo directory to be shared among deployers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,3 +16,5 @@ append :linked_files,
 append :linked_dirs, '.bundle', 'log', 'node_modules'
 
 set :passenger_restart_with_sudo, true
+
+before 'git:check', 'git:allow_shared'

--- a/lib/capistrano/tasks/git.rake
+++ b/lib/capistrano/tasks/git.rake
@@ -1,0 +1,10 @@
+namespace :git do
+  desc 'Allow use of shared git repository'
+  task :allow_shared do
+    on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
+      with fetch(:git_environmental_variables) do
+        execute :git, :config, '--global', '--replace-all', 'safe.directory', repo_path, repo_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
As of Git 2.35.2, Git will refuse to use `.git` directories that aren't owned by you. There are security concerns here: that other person could insert hooks, etc. to be run by you. In this case, we don't have a mix of user-privileges; anything one deployer can be forced to do could have just been done by the forcer directly.

Here, we add the repository repo to the deployer's list of "safe" git directories.

This will _eventually_ need to be done on all the rest of our repos, too. But app4 is affected now.