### PR TITLE
Remove moment.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,5 @@
 //= require datatables.net-bs4/js/dataTables.bootstrap4.js
 //= require rails-ujs
 //= require turbolinks
-//= require moment/moment
 //= require clipboard/dist/clipboard
 //= require_tree .

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "datatables.net-fixedheader-bs4": "^3.2.0",
     "jquery": "^3.5.0",
     "jquery-ui": "^1.13.2",
-    "moment": "^2.29.2",
     "popper.js": "^1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,11 +72,6 @@ jquery@>=1.7, "jquery@>=1.8.0 <4.0.0", jquery@^3.5.0:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
-moment@^2.29.2:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
-
 popper.js@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"


### PR DESCRIPTION
It's deprecated and we also aren't using it. It _was_ used in two places:

1. A "reactivation warning" that was removed in #151 
2. A brief foray into using jquery-datetimepicker, which was undone in #164