### PR TITLE
Fix logout link on "unauthorized" page

### DIFF
--- a/app/views/layouts/_navbar.haml
+++ b/app/views/layouts/_navbar.haml
@@ -33,4 +33,4 @@
       = link_to 'Site Feedback', feedback_index_path, class: 'nav-link'
     %li.nav-item
       = link_to 'Brochure', brochure_passengers_path, class: 'nav-link'
-  = link_to 'Logout', destroy_session_path, class: 'nav-link'
+  = link_to 'Logout', destroy_session_path, class: 'nav-link', method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,5 @@ Rails.application.routes.draw do
     post 'sessions/dev_login', to: 'sessions#dev_login'
   end
 
-  get 'sessions/unauthenticated', to: 'sessions#unauthenticated', as: :unauthenticated_session
-  get 'sessions/destroy', to: 'sessions#destroy', as: :destroy_session
+  delete 'sessions/destroy', to: 'sessions#destroy', as: :destroy_session
 end


### PR DESCRIPTION
Noticed that the "Logout" link on the [unauthorized page](https://github.com/umts/st-pax/blob/6c7420cfa434cea084f0bfb3f5db58628076191e/app/views/sessions/unauthenticated.haml#L29) didn't work. This was because that page expected it to be a `DELETE` route. That made more sense to me, so I ended up changing the one logout link that _wasn't_ a `DELETE` route instead.