### PR TITLE
Add a redirecting route for use with the site root

### DIFF
--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -6,9 +6,13 @@ class PassengersController < ApplicationController
   before_action :find_passenger, only: %i[show edit update destroy set_status]
   before_action :restrict_to_admin, only: %i[destroy]
   skip_before_action :require_authentication, only: :brochure
-  skip_before_action :restrict_to_employee, only: %i[brochure new edit create show register]
+  skip_before_action :restrict_to_employee, only: %i[brochure welcome new edit create show register]
 
   def brochure; end
+
+  def welcome
+    redirect_to @current_user.present? ? passengers_path : register_passengers_path
+  end
 
   def set_status
     msg = 'Passenger successfully updated'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root 'passengers#index'
+  root 'passengers#welcome'
 
   get '/github/callback' => 'github#callback'
 


### PR DESCRIPTION
I think passengers are given a link directly to `/register` but I don't see a reason to give them a 401 if they come right to the root of the site.