### PR TITLE
Some small Brochure layout changes

### DIFF
--- a/app/assets/stylesheets/passengers.scss
+++ b/app/assets/stylesheets/passengers.scss
@@ -1,7 +1,3 @@
-// Place all the styles related to the Passengers controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
-
 table#key, table#passengers {
   .expires-soon {
     background-color: #fffd8a;
@@ -20,4 +16,13 @@ table#key, table#passengers {
 
 .hide-view {
   display: none;
+}
+
+#brochure {
+  .table caption {
+    caption-side: top;
+    text-align: center;
+    font-weight: bolder;
+    color: inherit;
+  }
 }

--- a/app/views/passengers/brochure.html.haml
+++ b/app/views/passengers/brochure.html.haml
@@ -1,76 +1,75 @@
-%h1 SpecTrans Passenger Information
-.row
-  .col-md-6
-    %table.table
-      %caption Contact Information
-      %thead
-      %tbody
-        %tr
-          %th Phone
-          %td 413-545-2086
-        %tr
-          %th Public Website
-          %td= link_to 'www.umass.edu/transportation/special-transportation',
-            'https://www.umass.edu/transportation/special-transportation'
-        %tr
-          %th Email
-          %td stspv@umass.edu
-.row
-  .col-md-6
-    %table.table
-      %caption Special Transportation Staff
-      %thead
-      %tbody
-        %tr
-          %th Supervisors
-          %td Lisa Gagnon &amp; Shayla Keane
-        %tr
-          %th Coordinator
-          %td Diana Noble
-%h2 Hours of Operation
-.row
-  .col-md-6
-    %table.table
-      %caption Semester
-      %thead
-        %tr
-          %th{ 'aria-label': 'Days' }
-          %th Dispatch
-          %th Van
-      %tbody
-        %tr
-          %th{ scope: 'row'} Monday Through Friday
-          %td 7:00 AM to 5:00 PM
-          %td 7:15 AM to 8:15 PM
-        %tr
-          %th{ scope: 'row' } Saturday
-          %td none
-          %td 10:00 AM to 8:00 PM
-        %tr
-          %th{ scope: 'row' } Sunday
-          %td none
-          %td 10:00 AM to 8:00 PM
-.row
-  .col-md-6
-    %table.table
-      %caption Reduced Service (Holidays, Summer, Intersession)
-      %thead
-        %tr
-          %th{ 'aria-label': 'Days' }
-          %th Dispatch
-          %th Van
-      %tbody
-        %tr
-          %th{ scope: 'row'} Monday Through Friday
-          %td 8:00 AM to 5:00 PM
-          %td 7:15 AM to 7:15 PM
-        %tr
-          %th{ scope: 'row' } Saturday
-          %td none
-          %td 11:15 AM to 4:45 PM
-        %tr
-          %th{ scope: 'row' } Sunday
-          %td closed
-          %td closed
-= render 'policies'
-= render 'scheduling_rides_information'
+#brochure.container
+  %h1 SpecTrans Passenger Information
+  .row
+    .col-lg-6
+      %table.table
+        %caption Contact Information
+        %thead
+        %tbody
+          %tr
+            %th Phone
+            %td 413-545-2086
+          %tr
+            %th Public Website
+            %td= link_to 'www.umass.edu/transportation/special-transportation',
+              'https://www.umass.edu/transportation/special-transportation'
+          %tr
+            %th Email
+            %td stspv@umass.edu
+    .col-lg-6
+      %table.table
+        %caption Special Transportation Staff
+        %thead
+        %tbody
+          %tr
+            %th Supervisors
+            %td Lisa Gagnon &amp; Shayla Keane
+          %tr
+            %th Coordinator
+            %td Diana Noble
+  %h2 Hours of Operation
+  .row
+    .col-lg-6
+      %table.table
+        %caption Semester
+        %thead
+          %tr
+            %th{ 'aria-label': 'Days' }
+            %th Dispatch
+            %th Van
+        %tbody
+          %tr
+            %th{ scope: 'row'} Monday Through Friday
+            %td 7:00 AM to 5:00 PM
+            %td 7:15 AM to 8:15 PM
+          %tr
+            %th{ scope: 'row' } Saturday
+            %td none
+            %td 10:00 AM to 8:00 PM
+          %tr
+            %th{ scope: 'row' } Sunday
+            %td none
+            %td 10:00 AM to 8:00 PM
+    .col-lg-6
+      %table.table
+        %caption Reduced Service (Holidays, Summer, Intersession)
+        %thead
+          %tr
+            %th{ 'aria-label': 'Days' }
+            %th Dispatch
+            %th Van
+        %tbody
+          %tr
+            %th{ scope: 'row'} Monday Through Friday
+            %td 8:00 AM to 5:00 PM
+            %td 7:15 AM to 7:15 PM
+          %tr
+            %th{ scope: 'row' } Saturday
+            %td none
+            %td 11:15 AM to 4:45 PM
+          %tr
+            %th{ scope: 'row' } Sunday
+            %td closed
+            %td closed
+  = render 'policies'
+  = render 'scheduling_rides_information'


### PR DESCRIPTION
1. Wrap everything in a `.container` - to keep it from going to wide.
2. Allow two tables to sit next to each-other on lg+ screens
3. Place table caption at the top and make it more prominent; more like a "title".