### PR TITLE
Replace ST with AVS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## What is It?
 
-This app is a database of Special Transportation (ST) passengers, to be used by
-ST dispatchers and administrators.
+This app is a database of Accessible Van Service (AVS) passengers, to be used by
+AVS dispatchers and administrators.
 
 ## What Does It Do?
 
-Stores all ST passengers and their attributes. This allows for functionality
-such as automatically deactivating temporary ST passengers who have expired
+Stores all AVS passengers and their attributes. This allows for functionality
+such as automatically deactivating temporary AVS passengers who have expired
 doctors notes (done with a cron job that runs every day at 4:30am)
 
 ## Current Functionality
@@ -16,14 +16,14 @@ doctors notes (done with a cron job that runs every day at 4:30am)
 - Allows administrators to add, edit, and delete passengers (both temporary and
   permanent) from the database. Admins can also override passenger deactivation
   regardless of doctor's note expiration date
-- Allows on-duty ST dispatchers to add and edit temporary passengers in the
+- Allows on-duty AVS dispatchers to add and edit temporary passengers in the
   database
 - Database is searchable, sortable, and filterable.
 - Color-coded for easy identification of passengers who are not active and good
   to go (e.g., passengers without doctor's notes, those within a week of the
   expiration date, notes that have expired within the grace period ...)
 
-This app may later be expanded to serve other ST department needs, as well.
+This app may later be expanded to serve other AVS department needs, as well.
 
 ## Setup
 

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -42,7 +42,7 @@ class PassengersController < ApplicationController
 
   def edit
     if @registrant.present? && !@registrant&.pending?
-      flash[:warning] = 'To edit your profile, please call (413) 545-2086'
+      flash[:warning] = "To edit your profile, please call #{I18n.t 'department.phone'}"
       redirect_to passenger_path(@registrant)
     end
     @verification = @passenger.eligibility_verification || EligibilityVerification.new

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -42,7 +42,7 @@ class PassengersController < ApplicationController
 
   def edit
     if @registrant.present? && !@registrant&.pending?
-      flash[:warning] = "To edit your profile, please call #{I18n.t 'department.phone'}"
+      flash[:warning] = "To edit your profile, please call #{t 'department.phone'}"
       redirect_to passenger_path(@registrant)
     end
     @verification = @passenger.eligibility_verification || EligibilityVerification.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,8 +16,6 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  # POST /users
-  # POST /users.json
   def create
     @user = User.new(user_params)
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     return 'Add New Passenger' if @current_user.present?
     return 'Edit Registration' if @registrant&.persisted?
 
-    'Register for Special Transportation'
+    'Register for the Accessible Van Service'
   end
 
   def checkmark_glyph(value, options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     return 'Add New Passenger' if @current_user.present?
     return 'Edit Registration' if @registrant&.persisted?
 
-    'Register for the Accessible Van Service'
+    "Register for #{t 'department.name'}"
   end
 
   def checkmark_glyph(value, options = {})

--- a/app/helpers/passengers_helper.rb
+++ b/app/helpers/passengers_helper.rb
@@ -8,7 +8,7 @@ module PassengersHelper
   def registration_header
     return 'New Passenger' if @current_user.present?
 
-    'Register for the Accessible Van Service'
+    "Register for #{t 'department.name'}"
   end
 
   def verifying_agency_label

--- a/app/helpers/passengers_helper.rb
+++ b/app/helpers/passengers_helper.rb
@@ -8,7 +8,7 @@ module PassengersHelper
   def registration_header
     return 'New Passenger' if @current_user.present?
 
-    'Register for Special Transportation'
+    'Register for the Accessible Van Service'
   end
 
   def verifying_agency_label

--- a/app/mailers/passenger_mailer.rb
+++ b/app/mailers/passenger_mailer.rb
@@ -3,16 +3,16 @@
 class PassengerMailer < ApplicationMailer
   def notify_archived(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'Accessible Van Service Account Archived'
+    mail to: @passenger.email, subject: "#{t 'department.name'} Account Archived"
   end
 
   def notify_active(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'Accessible Van Service Account Confirmed'
+    mail to: @passenger.email, subject: "#{t 'department.name'} Account Confirmed"
   end
 
   def notify_pending(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'Accessible Van Service Account Created'
+    mail to: @passenger.email, subject: "#{t 'department.name'} Account Created"
   end
 end

--- a/app/mailers/passenger_mailer.rb
+++ b/app/mailers/passenger_mailer.rb
@@ -3,16 +3,16 @@
 class PassengerMailer < ApplicationMailer
   def notify_archived(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'Special Transit Account Archived'
+    mail to: @passenger.email, subject: 'Accessible Van Service Account Archived'
   end
 
   def notify_active(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'Special Transportation Account Confirmed'
+    mail to: @passenger.email, subject: 'Accessible Van Service Account Confirmed'
   end
 
   def notify_pending(passenger)
     @passenger = passenger
-    mail to: @passenger.email, subject: 'Special Transportation Account Created'
+    mail to: @passenger.email, subject: 'Accessible Van Service Account Created'
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{lang: 'en'}
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
-    %title ST Passengers
+    %title AVS Passengers
     = favicon_link_tag
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{lang: 'en'}
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
-    %title AVS Passengers
+    %title #{t 'department.abbr'} Passengers
     = favicon_link_tag
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/app/views/passenger_mailer/notify_active.haml
+++ b/app/views/passenger_mailer/notify_active.haml
@@ -1,9 +1,9 @@
 Dear #{@passenger.name},
 
-Your account with the Accessible Van Service has been activated. You can receive rides until #{@passenger.rides_expire ?  @passenger.rides_expire.strftime("%m/%d/%Y") : 'further notice'}.
+Your #{t 'department.name'} account has been activated. You can receive rides until #{@passenger.rides_expire ?  @passenger.rides_expire.strftime("%m/%d/%Y") : 'further notice'}.
 A link to the brochure, where our terms and policies are outlined, is included below.
 
-=link_to passenger_url('brochure'), passenger_url('brochure')
+=link_to nil, brochure_passengers_url
 
-This is an automated email related to your UMass Amherst Transit Account.
-For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/accessible-van-service
+This is an automated email related to your UMass Amherst #{t 'department.name'} Account.
+For more information, call us at #{t 'department.phone'}, email us at #{t 'department.email'}, or visit our website at #{t 'department.website'}

--- a/app/views/passenger_mailer/notify_active.haml
+++ b/app/views/passenger_mailer/notify_active.haml
@@ -1,9 +1,9 @@
 Dear #{@passenger.name},
 
-Your account with the Special Transportation Service has been activated. You can receive rides until #{@passenger.rides_expire ?  @passenger.rides_expire.strftime("%m/%d/%Y") : 'further notice'}.
+Your account with the Accessible Van Service has been activated. You can receive rides until #{@passenger.rides_expire ?  @passenger.rides_expire.strftime("%m/%d/%Y") : 'further notice'}.
 A link to the brochure, where our terms and policies are outlined, is included below.
 
 =link_to passenger_url('brochure'), passenger_url('brochure')
 
 This is an automated email related to your UMass Amherst Transit Account.
-For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/special-transportation
+For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/accessible-van-service

--- a/app/views/passenger_mailer/notify_archived.haml
+++ b/app/views/passenger_mailer/notify_archived.haml
@@ -3,4 +3,4 @@ Dear #{@passenger.name},
 Our records indicate that you only needed rides until #{Time.now.strftime("%m/%d/%Y")}, so we are archiving your account.
 
 This is an automated email related to your UMass Amherst Transit Account.
-For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/special-transportation
+For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/accessible-van-service

--- a/app/views/passenger_mailer/notify_archived.haml
+++ b/app/views/passenger_mailer/notify_archived.haml
@@ -2,5 +2,5 @@ Dear #{@passenger.name},
 
 Our records indicate that you only needed rides until #{Time.now.strftime("%m/%d/%Y")}, so we are archiving your account.
 
-This is an automated email related to your UMass Amherst Transit Account.
-For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/accessible-van-service
+This is an automated email related to your UMass Amherst #{t 'department.name'} Account.
+For more information, call us at #{t 'department.phone'}, email us at #{t 'department.email'}, or visit our website at #{t 'department.website'}

--- a/app/views/passenger_mailer/notify_pending.haml
+++ b/app/views/passenger_mailer/notify_pending.haml
@@ -1,9 +1,9 @@
 Dear #{@passenger.name},
 
-Your account with the Special Transportation Service has been created but is still pending. You can receive rides until #{3.business_days.after(Time.now).strftime("%m/%d/%Y")}.
+Your account with the Accessible Van Service has been created but is still pending. You can receive rides until #{3.business_days.after(Time.now).strftime("%m/%d/%Y")}.
 Once your account has been activated, we will notify you of the date until which you can receive rides. Before using our service, please read the brochure at our website at this link:
 
 =link_to passenger_url('brochure'), passenger_url('brochure')
 
 This is an automated email related to your UMass Amherst Transit Account.
-For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/special-transportation
+For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/accessible-van-service

--- a/app/views/passenger_mailer/notify_pending.haml
+++ b/app/views/passenger_mailer/notify_pending.haml
@@ -1,9 +1,9 @@
 Dear #{@passenger.name},
 
-Your account with the Accessible Van Service has been created but is still pending. You can receive rides until #{3.business_days.after(Time.now).strftime("%m/%d/%Y")}.
+Your #{t 'department.name'} account has been created but is still pending. You can receive rides until #{3.business_days.after(Time.now).strftime("%m/%d/%Y")}.
 Once your account has been activated, we will notify you of the date until which you can receive rides. Before using our service, please read the brochure at our website at this link:
 
-=link_to passenger_url('brochure'), passenger_url('brochure')
+=link_to nil, brochure_passengers_url
 
-This is an automated email related to your UMass Amherst Transit Account.
-For more information, call us at (413)545-2086, email us at stspv@umass.edu, or visit our website at www.umass.edu/transportation/accessible-van-service
+This is an automated email related to your UMass Amherst #{t 'department.name'} Account.
+For more information, call us at #{t 'department.phone'}, email us at #{t 'department.email'}, or visit our website at #{t 'department.website'}

--- a/app/views/passengers/_policies.html.haml
+++ b/app/views/passengers/_policies.html.haml
@@ -9,7 +9,7 @@
     same destination as the passenger.
   %li
     In the unlikely event of an accident, please remain calm. If you are
-    injured, please notify the driver immediately. SpecTrans policy requires
+    injured, please notify the driver immediately. AVS policy requires
     that the driver remain at the scene until the police and a staff member have
     arrived and cleared the scene. We will not be able to bring you to your
     destination until another van can be sent out to continue the ride.
@@ -23,7 +23,7 @@
     your back facing the van. Please lock your wheels or turn the power off to
     prevent any movement of the chair while the lift is in motion.
   %li 
-    As a passenger in SpecTrans vans you are required, by Massachusetts State
+    As a passenger in AVS vans you are required, by Massachusetts State
     Law: MGL Part 1, Title XIV, Chapter 90, Section 13A, to have your seat belt
     fastened at all times while the vehicle is in motion.
   %li 
@@ -33,7 +33,7 @@
     Van service is provided whenever possible during inclement weather. In the
     event of a snow or ice storm, however, we will discourage people from using
     our service unless absolutely necessary. If the University delays or cancels
-    classes, SpecTrans will assume all rides are cancelled unless you call to
+    classes, AVS will assume all rides are cancelled unless you call to
     reschedule.
   %li
     Alcohol is not permitted on the vans under any circumstances. If you try to

--- a/app/views/passengers/_policies.html.haml
+++ b/app/views/passengers/_policies.html.haml
@@ -2,17 +2,17 @@
 %ul
   %li
     Passengers are allowed to bring two reasonably sized, easily controlled
-    packages on board. Large items, such as skis, carriages, bikes, etc. will 
+    packages on board. Large items, such as skis, carriages, bikes, etc. will
     not be permitted on the vans.
   %li
     Passengers are allowed two friends per ride as long as they are going to the
     same destination as the passenger.
   %li
     In the unlikely event of an accident, please remain calm. If you are
-    injured, please notify the driver immediately. AVS policy requires
-    that the driver remain at the scene until the police and a staff member have
-    arrived and cleared the scene. We will not be able to bring you to your
-    destination until another van can be sent out to continue the ride.
+    injured, please notify the driver immediately. #{t 'department.abbr'} policy
+    requires that the driver remain at the scene until the police and a staff
+    member have arrived and cleared the scene. We will not be able to bring you
+    to your destination until another van can be sent out to continue the ride.
   %li
     Animals are not allowed aboard the vans, with the exception of certified
     service animals.
@@ -22,19 +22,19 @@
     is ready for you to board, you should position yourself on the lift with
     your back facing the van. Please lock your wheels or turn the power off to
     prevent any movement of the chair while the lift is in motion.
-  %li 
-    As a passenger in AVS vans you are required, by Massachusetts State
-    Law: MGL Part 1, Title XIV, Chapter 90, Section 13A, to have your seat belt
-    fastened at all times while the vehicle is in motion.
-  %li 
+  %li
+    As a passenger in #{t 'department.abbr'} vans you are required, by
+    Massachusetts State Law: MGL Part 1, Title XIV, Chapter 90, Section 13A, to
+    have your seat belt fastened at all times while the vehicle is in motion.
+  %li
     Rides from an off-campus location to another off-campus locations are
     limited to two per week and must be after 5:00pm.
-  %li 
+  %li
     Van service is provided whenever possible during inclement weather. In the
     event of a snow or ice storm, however, we will discourage people from using
     our service unless absolutely necessary. If the University delays or cancels
-    classes, AVS will assume all rides are cancelled unless you call to
-    reschedule.
+    classes, #{t 'department.abbr'} will assume all rides are cancelled unless
+    you call to reschedule.
   %li
     Alcohol is not permitted on the vans under any circumstances. If you try to
     get on a van with any alcoholic substance, the driver will refuse the ride.

--- a/app/views/passengers/_scheduling_rides_information.html.haml
+++ b/app/views/passengers/_scheduling_rides_information.html.haml
@@ -1,7 +1,7 @@
 %h2 Scheduling Rides
 %ul 
   %li
-    SpecTrans vans travel on campus and in close proximity to the University,
+    Accessible vans travel on campus and in close proximity to the University,
     we do not travel more than 3 miles from Du Bois Library. 
   %li
     When you call to schedule rides, you will speak to either the Dispatcher 
@@ -28,7 +28,7 @@
     There is generally one pick-up/drop-off spot per building. If you are unsure
     where the spot is for a building, please ask the dispatcher when you
     schedule the ride. DO NOT ask drivers to drop you off anywhere else. If you
-    need special accommodations, please email the ST Supervisors at
+    need special accommodations, please email the AVS Supervisors at
     stspv@umass.edu
   %li
     A no-show is a ride that you miss completely, are more than five minutes

--- a/app/views/passengers/_scheduling_rides_information.html.haml
+++ b/app/views/passengers/_scheduling_rides_information.html.haml
@@ -1,14 +1,14 @@
 %h2 Scheduling Rides
-%ul 
+%ul
   %li
-    Accessible vans travel on campus and in close proximity to the University,
-    we do not travel more than 3 miles from Du Bois Library. 
+    #{t 'department.name'} vans travel on campus and in close proximity to the
+    University, we do not travel more than 3 miles from Du Bois Library.
   %li
-    When you call to schedule rides, you will speak to either the Dispatcher 
+    When you call to schedule rides, you will speak to either the Dispatcher
     (during the weekday) or the Bus Radio Operator (nights and weekends). Keep
     in mind that the Dispatcher is more knowledgeable about the service, so you
     should reserve your more complicated questions for weekdays.
-  %li 
+  %li
     Permanent rides are those which you will need every week for the entire
     semester. You may schedule permanent rides during the first two weeks
     of the semester, and you may update them at any time. If you don’t need
@@ -23,13 +23,15 @@
   %li
     Following some holidays during the semester, the University will designate
     that a certain day of the week will follow another day’s class schedule.
-    On such days, our schedules will be adjusted accordingly. 
+    On such days, our schedules will be adjusted accordingly.
   %li
     There is generally one pick-up/drop-off spot per building. If you are unsure
     where the spot is for a building, please ask the dispatcher when you
     schedule the ride. DO NOT ask drivers to drop you off anywhere else. If you
-    need special accommodations, please email the AVS Supervisors at
-    stspv@umass.edu
+    need special accommodations, please email the #{t 'department.abbr'}
+    Supervisors at
+    = succeed '.' do
+      = mail_to t('department.email')
   %li
     A no-show is a ride that you miss completely, are more than five minutes
     late for, or that you cancel with less than two hours notice. Passengers
@@ -40,6 +42,7 @@
     A lateness is a ride for which you are more than 3 minutes late. Passengers
     who are late eight (8) or more times in a thirty day period, may be
     suspended from the service for one week. Van will wait exactly 5 minutes
-    before they move on. 
+    before they move on.
   %li
-    If your driver is not there within 3 minutes, call the Dispatcher at 413-545-2086.
+    If your driver is not there within 3 minutes, call the Dispatcher at
+    #{t 'department.phone'}.

--- a/app/views/passengers/brochure.html.haml
+++ b/app/views/passengers/brochure.html.haml
@@ -1,5 +1,5 @@
 #brochure.container
-  %h1 Accessible Van Service Passenger Information
+  %h1 #{t 'department.name'} Passenger Information
   .row
     .col-lg-6
       %table.table
@@ -8,25 +8,24 @@
         %tbody
           %tr
             %th Phone
-            %td 413-545-2086
+            %td= t 'department.phone'
           %tr
             %th Public Website
-            %td= link_to 'www.umass.edu/transportation/accessible-van-service',
-              'https://www.umass.edu/transportation/accessible-van-service'
+            %td= link_to nil, t('department.website')
           %tr
             %th Email
-            %td stspv@umass.edu
+            %td= t 'department.email'
     .col-lg-6
       %table.table
-        %caption Accessible Van Service Staff
+        %caption #{t 'department.name'} Staff
         %thead
         %tbody
           %tr
-            %th Supervisors
-            %td Aurora O'Connor &amp; Karina Patterson
+            %th= 'Supervisor'.pluralize t('department.supervisors').size
+            %td= t('department.supervisors').to_sentence
           %tr
-            %th Coordinator
-            %td Diana Noble
+            %th= 'Coordinator'.pluralize t('department.coordinators').size
+            %td= t('department.coordinators').to_sentence
   %h2 Hours of Operation
   .row
     .col-lg-6

--- a/app/views/passengers/brochure.html.haml
+++ b/app/views/passengers/brochure.html.haml
@@ -1,5 +1,5 @@
 #brochure.container
-  %h1 SpecTrans Passenger Information
+  %h1 Accessible Van Service Passenger Information
   .row
     .col-lg-6
       %table.table
@@ -11,19 +11,19 @@
             %td 413-545-2086
           %tr
             %th Public Website
-            %td= link_to 'www.umass.edu/transportation/special-transportation',
-              'https://www.umass.edu/transportation/special-transportation'
+            %td= link_to 'www.umass.edu/transportation/accessible-van-service',
+              'https://www.umass.edu/transportation/accessible-van-service'
           %tr
             %th Email
             %td stspv@umass.edu
     .col-lg-6
       %table.table
-        %caption Special Transportation Staff
+        %caption Accessible Van Service Staff
         %thead
         %tbody
           %tr
             %th Supervisors
-            %td Lisa Gagnon &amp; Shayla Keane
+            %td Aurora O'Connor &amp; Karina Patterson
           %tr
             %th Coordinator
             %td Diana Noble

--- a/app/views/sessions/subsidiary.html.haml
+++ b/app/views/sessions/subsidiary.html.haml
@@ -1,4 +1,4 @@
-%h1 Welcome to the website for the Accessible Van Service.
+%h1 Welcome to the #{t 'department.name'} website.
 %h2 Subsidiary account:
 %p
   You are attempting to login with #{@uid}, which is a role subsidiary account

--- a/app/views/sessions/subsidiary.html.haml
+++ b/app/views/sessions/subsidiary.html.haml
@@ -1,4 +1,4 @@
-%h1 Welcome to the website for Special Transportation.
+%h1 Welcome to the website for the Accessible Van Service.
 %h2 Subsidiary account:
 %p
   You are attempting to login with #{@uid}, which is a role subsidiary account

--- a/app/views/sessions/unauthenticated.haml
+++ b/app/views/sessions/unauthenticated.haml
@@ -1,4 +1,4 @@
-%h1 Welcome to the website for Special Transportation.
+%h1 Welcome to the website for the Accessible Van Service.
 %h2 You are not allowed on this page.
 %p
   Some possible scenarios:
@@ -6,15 +6,11 @@
     %li
       You are a current or future passenger. In this case, you might be
       interested in our
-      = link_to 'brochure.', brochure_passengers_path
+      = succeed '.' do
+        = link_to 'brochure', brochure_passengers_path
     %li
-      You are an employee of UMass Transit, but we haven't added you to our
-      database yet. In this case, please talk to an ST Supervisor or contact
-      IT.
-    %li
-      You are an employee of UMass Transit and should be able to log in.
-      If this is the case, please talk to an ST Supervisor to get it sorted
-      out.
+      You are an employee of UMass Transit and believe that you should have
+      access. If this is the case, please contact AVS staff for assistance.
     %li
       You are neither an employee nor a passenger. In this case, you might be
       looking for our public website, where you can access

--- a/app/views/sessions/unauthenticated.haml
+++ b/app/views/sessions/unauthenticated.haml
@@ -1,4 +1,4 @@
-%h1 Welcome to the website for the Accessible Van Service.
+%h1 Welcome to the #{t 'department.name'} website.
 %h2 You are not allowed on this page.
 %p
   Some possible scenarios:
@@ -9,8 +9,9 @@
       = succeed '.' do
         = link_to 'brochure', brochure_passengers_path
     %li
-      You are an employee of UMass Transit and believe that you should have
-      access. If this is the case, please contact AVS staff for assistance.
+      You are a #{t 'department.name'} employee and believe that you should have
+      access. If this is the case, please contact #{t 'department.abbr'} staff
+      for assistance.
     %li
       You are neither an employee nor a passenger. In this case, you might be
       looking for our public website, where you can access

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -7,7 +7,7 @@
           %th Name
           %th Spire ID
           %th.text-center Active?
-          %th.text-center STSPV?
+          %th.text-center Staff?
           %th
           %th
       %tbody

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,3 +60,15 @@ en:
       user:
         active: 'Active?'
         admin:  'Admin?'
+  department:
+    name: Accessible Van Service
+    abbr: AVS
+    phone: 413-545-2086
+    email: stspv@umass.edu
+    website: https://www.umass.edu/transportation/accessible-van-service
+    coordinators:
+      - Diana Noble
+    supervisors:
+      - "Aurora O'Connor"
+      - Karina Patterson
+      - Zack Suranofsky

--- a/spec/mailers/passenger_mailer_spec.rb
+++ b/spec/mailers/passenger_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe PassengerMailer do
     end
 
     it 'has correct subject' do
-      expect(output.subject).to eql 'Accessible Van Service Account Confirmed'
+      expect(output.subject).to eq "#{I18n.t 'department.name'} Account Confirmed"
     end
   end
 end

--- a/spec/mailers/passenger_mailer_spec.rb
+++ b/spec/mailers/passenger_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe PassengerMailer do
     end
 
     it 'has correct subject' do
-      expect(output.subject).to eql 'Special Transportation Account Confirmed'
+      expect(output.subject).to eql 'Accessible Van Service Account Confirmed'
     end
   end
 end


### PR DESCRIPTION
I went the extra step of moving the department, staff, and contact info into the locales file.

This is almost all of #328, but I'm still working on redoing auth on this app in order to allow us to deploy the app at a different URL than st-pax.admin.umass.edu.