### PR TITLE
Update spire-lookup.ps1 to account for null uids

### DIFF
--- a/contrib/spire-lookup.ps1
+++ b/contrib/spire-lookup.ps1
@@ -10,7 +10,8 @@ foreach($row in (Import-Csv -Path $inFile)) {
   If ($userLookup -ne $null) {
     # External object IDs are prefixed with the object type
     # e.g. 'User_0d0d947f-25b0-4a5a-b9a8-0094d1221ca3'
-    $uid = $userLookup.("msDS-ExternalDirectoryObjectId").split("_")[-1]
+    $uid = $userLookup.("msDS-ExternalDirectoryObjectId")
+    If ($uid -ne $null) { $uid = $uid.split("_")[-1] }
 
     New-Object -TypeName PSObject -Property @{
       id = $row.id


### PR DESCRIPTION
Occasionally, folks _are_ still in on-prem AD, but their account is inactive (recently left?) and they've never been synced to Azure AD. In those cases, the "external directory object id" property is missing/null.