### PR TITLE
Ease up on the passenger index

### DIFF
--- a/db/migrate/20230922123246_add_spire_unique_indices.rb
+++ b/db/migrate/20230922123246_add_spire_unique_indices.rb
@@ -1,6 +1,6 @@
 class AddSpireUniqueIndices < ActiveRecord::Migration[6.1]
   def change
-    add_index :passengers, :spire, unique: true
+    add_index :passengers, :spire
     add_index :users, :spire, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2023_09_22_123246) do
     t.string "uid"
     t.string "net_id"
     t.index ["net_id"], name: "index_passengers_on_net_id"
-    t.index ["spire"], name: "index_passengers_on_spire", unique: true
+    t.index ["spire"], name: "index_passengers_on_spire"
     t.index ["uid"], name: "index_passengers_on_uid"
   end
 


### PR DESCRIPTION
Turns out that there are a ton of (invalid) Passengers in prod with a `nil` Spire ID. I'm just going to punt on this one given that I _hope_ to be removing that column at some point.