### PR TITLE
Enabled rubocop-capybara & rubocop-factory_bot

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 require:
+  - rubocop-capybara
+  - rubocop-factory_bot
   - rubocop-rake
   - rubocop-rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ group :development do
   gem 'haml-lint'
   gem 'listen'
   gem 'rubocop'
+  gem 'rubocop-capybara'
+  gem 'rubocop-factory_bot'
   gem 'rubocop-rake'
   gem 'rubocop-rspec'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,12 +319,12 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
-    rubocop-rake (0.6.0)
-      rubocop (~> 1.0)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)
       rubocop (~> 1.41)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
     rubocop-rspec (2.26.1)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
@@ -437,6 +437,8 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   rubocop
+  rubocop-capybara
+  rubocop-factory_bot
   rubocop-rake
   rubocop-rspec
   sassc-rails

--- a/spec/factories/eligibility_verifications.rb
+++ b/spec/factories/eligibility_verifications.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   end
 
   trait :with_agency do
-    association :verifying_agency
+    verifying_agency
   end
 
   trait :unexpired do


### PR DESCRIPTION
I _think_ that this is actually a no-op: they're dependencies of rubocop-rspec, which makes me think that that gem uses these two already. But rubocop says, "hey, don't you want to enable these gems?"