### PR TITLE
Remove erb2haml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ group :development do
   gem 'capistrano-pending', require: false
   gem 'capistrano-rails', require: false
   gem 'ed25519', require: false
-  gem 'erb2haml'
   gem 'haml-lint'
   gem 'listen'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,8 +121,6 @@ GEM
     diff-lcs (1.5.1)
     docile (1.3.5)
     ed25519 (1.3.0)
-    erb2haml (0.1.5)
-      html2haml
     erubi (1.13.0)
     erubis (2.7.0)
     exception_notification (4.5.0)
@@ -438,7 +436,6 @@ DEPENDENCIES
   capistrano-rails
   capybara
   ed25519
-  erb2haml
   exception_notification
   factory_bot_rails
   ffaker


### PR DESCRIPTION
We don't need to convert any more erb files at this point.