### PR TITLE
Add npm to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     ignore:
       - dependency-name: rails
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Several recent PRs have dramatically increased the number of packages in `package.json`. Probably good to start keeping an eye on these too.