### PR TITLE
Two small fixes for the dispatch log

### DIFF
--- a/app/views/log_entries/_form.html.haml
+++ b/app/views/log_entries/_form.html.haml
@@ -1,11 +1,10 @@
-= bootstrap_form_with model: log_entry, local: true do |f|
-  = f.text_area :text, required: true, rows: 6, hide_label: true, 'aria-label': 'Text'
+= bootstrap_form_with model: log_entry, namespace: log_entry.id, local: true do |f|
+  = f.text_area :text, required: true, rows: 6, hide_label: true
   .d-flex
     = f.primary log_entry.persisted? ? 'Save' : 'Submit'
     - if @current_user.admin?
       .input-group.ml-2
         .input-group-text
           .custom-control.custom-checkbox
-            - pinned_id = log_entry.persisted? ? "log-entry-#{log_entry.id}-pinned" : 'log-entry-pinned'
-            = f.check_box_without_bootstrap :pinned, id: pinned_id, class: 'custom-control-input'
-            = f.label :pinned, for: pinned_id, class: 'custom-control-label'
+            = f.check_box_without_bootstrap :pinned, class: 'custom-control-input'
+            = f.label :pinned, class: 'custom-control-label'

--- a/app/views/log_entries/index.html.haml
+++ b/app/views/log_entries/index.html.haml
@@ -18,10 +18,9 @@
                 %i.fa-solid.fa-thumbtack
                 .sr-only Pinned
             %strong= entry.user&.name || 'Unknown'
-            = link_to '#', title: entry.created_at.strftime('%A, %B, %d, %Y %-I:%M %p'),
-                      class: 'text-muted', 'data-toggle': 'tooltip' do
-              = time_ago_in_words(entry.created_at)
-              ago
+            %span.text-muted{ title: entry.created_at.strftime('%A, %B, %d, %Y %-I:%M %p'),
+                              tabindex: 0, 'data-toggle': 'tooltip' }
+              #{time_ago_in_words(entry.created_at)} ago
           - if @current_user.can_modify? entry
             .d-flex
               = button_tag type: :button, class: 'log-entry-edit-button btn btn-sm' do


### PR DESCRIPTION
1. Add form namespace for log entries: This changes how the ids for form elements are generated, and prevents
collisions between `for=` values. We had manually done that with the pinned checkbox, but not the text box, leading to some accessibility errors.
2. Change log timestamp from link to span: It seemed weird to me that the timestamp was a "link" that didn't go anywhere.