### PR TITLE
Fix Bootstrap not modifying jQuery on initial load

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,8 @@
 //= require clipboard/dist/clipboard
 //= require_tree .
 
-$(document).on('turbo:load', function () {
-  $('[data-toggle="tooltip"]').tooltip();
+document.addEventListener('turbo:load', function () {
+  document.querySelectorAll('[data-toggle="tooltip"]').forEach(function (element) {
+    new bootstrap.Tooltip(element);
+  });
 });


### PR DESCRIPTION
Happened to have the console open looking for something else and noticed this:

```
Uncaught TypeError: $(...).tooltip is not a function
    <anonymous> https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:35
    dispatch https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:2
    handle https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:2
    a https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:6
    notifyApplicationAfterPageLoad https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:22
    pageBecameInteractive https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:22
    pageIsInteractive https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:21
    interpretReadyState https://st-pax.admin.umass.edu/assets/application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:21
application-cf19bfb9219d9fe12d2b48f4d0bc60e9d0fdec7fdcfced4d98fed6722d659808.js:35:637
```

Seems like jQuery isn't there for Bootstrap to add-on to at first page load. It _did_ work on Turbo navigation, however. So if you _navigated_ to a page with tooltips, they worked. But if you reloaded the page, got there from an external link, etc. they didn't

Spent some time trouble-shooting, but it was just as easy not to use jQuery in this case.