### PR TITLE
MobilityDevicesController Returns Correct 404 Error

### DIFF
--- a/app/controllers/mobility_devices_controller.rb
+++ b/app/controllers/mobility_devices_controller.rb
@@ -48,7 +48,7 @@ class MobilityDevicesController < ApplicationController
   private
 
   def set_device
-    @device = MobilityDevice.find params.require(:id)
+    @device = MobilityDevice.find params[:id]
   end
 
   def device_params

--- a/app/controllers/mobility_devices_controller.rb
+++ b/app/controllers/mobility_devices_controller.rb
@@ -48,8 +48,7 @@ class MobilityDevicesController < ApplicationController
   private
 
   def set_device
-    @device = MobilityDevice.find_by id: params.require(:id)
-    head :not_found if @device.blank?
+    @device = MobilityDevice.find params.require(:id)
   end
 
   def device_params


### PR DESCRIPTION
Closes #551 

`MobilityDevicesController#set_device` will now return the standard `ActiveRecord::RecordNotFound` error if the mobility device can't be found. This will render the 404 page in development instead of a blank one. This matches the `PassengersController` and `UsersController`.