### PR TITLE
Add and configure rspec-retry for system tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :test do
   gem 'rack_session_access'
   gem 'rspec-html-matchers'
   gem 'rspec-rails'
+  gem 'rspec-retry'
   gem 'selenium-webdriver'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.13.2)
     rubocop (1.73.2)
       json (~> 2.3)
@@ -509,6 +511,7 @@ DEPENDENCIES
   rake
   rspec-html-matchers
   rspec-rails
+  rspec-retry
   rubocop
   rubocop-capybara
   rubocop-factory_bot
@@ -664,6 +667,7 @@ CHECKSUMS
   rspec-html-matchers (0.10.0) sha256=d424bfeb0104884478be299b6695b56c2d0432bb77dc9cedecb5138e91c0e9ae
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
+  rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
   rubocop (1.73.2) sha256=35cd1b1365ba97234323fe771abcecd09c9b77098464cd726c76aa7d9bc12b5d
   rubocop-ast (1.38.1) sha256=80ecbe2ac9bb26693cab9405bf72b41b85a1f909f20f021b983c32c2e7d857fe

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 require 'rspec-html-matchers'
+require 'rspec/retry'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'rack_session_access/capybara'
@@ -22,10 +23,22 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+
+  config.retry_callback = proc do |example|
+    Capybara.reset! if example.metadata[:js]
+  end
+
   config.before :each, type: :system do
     driven_by :rack_test
   end
+
   config.before :each, :js, type: :system do
     driven_by :selenium, using: :headless_chrome
+  end
+
+  config.around :each, :js, type: :system do |example|
+    example.run_with_retry retry: 3
   end
 end


### PR DESCRIPTION
The contagion of

```
Selenium::WebDriver::Error::UnknownError:
   unknown error: unhandled inspector error: {"code":-32000,"message":"Node with given id does not belong to the document"}
```

has spread to this app, I guess. Google hasn't really gotten me much.