### PR TITLE
Enable yjit

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -59,4 +59,4 @@ Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
 # deploying to a memory constrained environment you may want to set this to `false`.
 #++
-# Rails.application.config.yjit = true
+Rails.application.config.yjit = true


### PR DESCRIPTION
I guess there's a chance our VM could be considered a "memory constrained" environment. I do want to keep an eye on the server for a bit after deployment.