### PR TITLE
Fix Font Awesome v7 breaks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,10 @@
+@use "@fortawesome/fontawesome-free/scss/variables" with (
+  $font-path: "@fortawesome/fontawesome-free/webfonts"
+);
+@use "@fortawesome/fontawesome-free/scss/fontawesome";
+@use "@fortawesome/fontawesome-free/scss/fa" as fa;
+@use "@fortawesome/fontawesome-free/scss/solid" as fas;
+
 $primary: #881c1c;
 $secondary: #63666a;
 $success: #76881d;
@@ -11,10 +18,6 @@ $dark: #333333;
 
 @import "datatables.net-bs5/css/dataTables.bootstrap5";
 @import "datatables.net-fixedheader-bs5/css/fixedHeader.bootstrap5";
-
-$fa-font-path: "@fortawesome/fontawesome-free/webfonts";
-@import "@fortawesome/fontawesome-free/scss/fontawesome";
-@import "@fortawesome/fontawesome-free/scss/solid";
 
 @import "passengers";
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
       concat content_tag :span, nil,
                          class: ['fa-solid', "#{word}-glyph", options.fetch(word.to_sym)],
                          aria: { hidden: 'true' }, title: word
-      concat content_tag :span, word, class: 'sr-only'
+      concat content_tag :span, word, class: 'visually-hidden'
     end
   end
 

--- a/app/views/log_entries/index.html.haml
+++ b/app/views/log_entries/index.html.haml
@@ -16,7 +16,7 @@
             - if entry.pinned?
               %span.text-primary.mr-2
                 %i.fa-solid.fa-thumbtack
-                .sr-only Pinned
+                .visually-hidden Pinned
             %strong= entry.user&.name || 'Unknown'
             - title = entry.created_at.strftime('%A, %B, %d, %Y %-I:%M %p')
             %span.text-muted{ title:, tabindex: 0, data: { toggle: 'tooltip' } }

--- a/app/views/passengers/_filters_and_key.html.haml
+++ b/app/views/passengers/_filters_and_key.html.haml
@@ -3,7 +3,7 @@
     = bootstrap_form_tag url: '#', method: :get do |f|
       = f.form_group do
         %fieldset
-          %legend.sr-only Filter Passengers
+          %legend.visually-hidden Filter Passengers
           - %w[permanent temporary all].each do |filter|
             = f.radio_button :filter, filter, label: filter.capitalize, checked: @filter == filter, inline: true
       = f.submit 'Print', formaction: passengers_path(format: :pdf)

--- a/app/views/passengers/brochure/_hours.html.haml
+++ b/app/views/passengers/brochure/_hours.html.haml
@@ -1,6 +1,6 @@
 .row
   .col-lg-6
-    %h2.sr-only Hours
+    %h2.visually-hidden Hours
     %table.table
       %caption.h5.text-center Semester Hours
       %thead

--- a/app/views/passengers/index.html.haml
+++ b/app/views/passengers/index.html.haml
@@ -17,14 +17,14 @@
         - if @status == :pending
           %th.text-center Eligibility Verified
         %th{ data: { orderable: 'false' } }
-          .sr-only View
+          .visually-hidden View
         %th{ data: { orderable: 'false' } }
-          .sr-only Edit
+          .visually-hidden Edit
         %th{ data: { orderable: 'false' } }
-          .sr-only= status_action_settings(@status)[:text]
+          .visually-hidden= status_action_settings(@status)[:text]
         - if @current_user.admin?
           %th{ data: { orderable: 'false' } }
-            .sr-only Delete
+            .visually-hidden Delete
     %tbody
       - @passengers.each do |passenger|
         %tr{ class: passengers_table_row_class(passenger), data: { email: passenger.email } }


### PR DESCRIPTION
Two problems caused by #695

1. FA un-prefixed their variables. They did this because _if_ you use `@use` then you can namespace them yourself if you need them.
2. Bootstrap removed `.sr-only` a while ago, but FA _also_ had a class called `sr-only` that they used internally until now.