### PR TITLE
Change deprecated `:unprocessable_entity` statuses

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -26,7 +26,7 @@ class FeedbackController < ApplicationController
       redirect_to feedback_path(@feedback.issue.number)
     else
       flash.now[:danger] = @feedback.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/mobility_devices_controller.rb
+++ b/app/controllers/mobility_devices_controller.rb
@@ -22,7 +22,7 @@ class MobilityDevicesController < ApplicationController
       redirect_to mobility_devices_url
     else
       flash.now[:danger] = @device.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -32,7 +32,7 @@ class MobilityDevicesController < ApplicationController
       redirect_to mobility_devices_url
     else
       flash.now[:danger] = @device.errors.full_messages
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/passengers_controller.rb
+++ b/app/controllers/passengers_controller.rb
@@ -84,7 +84,7 @@ class PassengersController < ApplicationController
     @passenger = Passenger.new(passenger_params)
     @passenger.registerer = @current_user
     success = -> { redirect_to @passenger }
-    failure = -> { render :new, status: :unprocessable_entity }
+    failure = -> { render :new, status: :unprocessable_content }
 
     try_notifying_passenger success:, failure:, success_message: t('.success') do
       @passenger.save
@@ -94,7 +94,7 @@ class PassengersController < ApplicationController
   def update
     @passenger.assign_attributes passenger_params
     success = -> { redirect_to @passenger }
-    failure = -> { render :edit, status: :unprocessable_entity }
+    failure = -> { render :edit, status: :unprocessable_content }
 
     try_notifying_passenger success:, failure:, success_message: t('.registrant_success') do
       @passenger.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
       redirect_to users_url
     else
       flash.now[:danger] = @user.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
       redirect_to users_url
     else
       flash.now[:danger] = @user.errors.full_messages
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/spec/requests/mobility_devices_spec.rb
+++ b/spec/requests/mobility_devices_spec.rb
@@ -128,9 +128,9 @@ RSpec.describe 'Mobility Devices' do
           expect { submit }.not_to change(MobilityDevice, :count)
         end
 
-        it 'returns an unprocessable entity status' do
+        it 'returns an unprocessable content status' do
           submit
-          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_http_status :unprocessable_content
         end
       end
 
@@ -141,9 +141,9 @@ RSpec.describe 'Mobility Devices' do
           expect { submit }.not_to change(MobilityDevice, :count)
         end
 
-        it 'returns an unprocessable entity status' do
+        it 'returns an unprocessable content status' do
           submit
-          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_http_status :unprocessable_content
         end
       end
     end
@@ -258,9 +258,9 @@ RSpec.describe 'Mobility Devices' do
           expect { submit }.not_to(change { device.reload.attributes })
         end
 
-        it 'returns an unprocessable entity status' do
+        it 'returns an unprocessable content status' do
           submit
-          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_http_status :unprocessable_content
         end
       end
 
@@ -271,9 +271,9 @@ RSpec.describe 'Mobility Devices' do
           expect { submit }.not_to(change { device.reload.attributes })
         end
 
-        it 'returns an unprocessable entity status' do
+        it 'returns an unprocessable content status' do
           submit
-          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_http_status :unprocessable_content
         end
       end
     end


### PR DESCRIPTION
Rack has deprecated it in favor of `:unprocessable_content` (which is the name of the status code in the HTTP spec)