### PR TITLE
Configure npm with engine-strict=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
This is less necessary due to the newer node verison, but maybe we just throw it in anyways?
