### PR TITLE
Update schema definition

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,75 +10,75 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_26_202921) do
+ActiveRecord::Schema[8.1].define(version: 2024_01_26_202921) do
   create_table "eligibility_verifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "passenger_id"
-    t.date "expiration_date"
+    t.text "address"
     t.datetime "created_at", precision: nil, null: false
+    t.date "expiration_date"
+    t.string "name"
+    t.integer "passenger_id"
+    t.string "phone"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "verifying_agency_id"
-    t.string "name"
-    t.text "address"
-    t.string "phone"
     t.index ["passenger_id"], name: "index_eligibility_verifications_on_passenger_id", unique: true
   end
 
   create_table "issue_tokens", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "token"
-    t.integer "singleton"
     t.datetime "created_at", null: false
+    t.integer "singleton"
+    t.string "token"
     t.datetime "updated_at", null: false
     t.index ["singleton"], name: "index_issue_tokens_on_singleton", unique: true
   end
 
   create_table "log_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "user_id"
-    t.text "text"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.boolean "pinned", default: false, null: false
+    t.text "text"
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
   end
 
   create_table "mobility_devices", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "name"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.string "name"
     t.boolean "needs_longer_rides", default: false, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_mobility_devices_on_name", unique: true
   end
 
   create_table "passengers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
     t.string "address"
-    t.string "phone"
-    t.boolean "permanent", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.text "note"
+    t.string "email"
     t.integer "mobility_device_id"
-    t.string "spire"
+    t.string "name"
+    t.string "net_id"
+    t.text "note"
+    t.boolean "permanent", default: false, null: false
+    t.string "phone"
     t.integer "registered_by"
-    t.integer "registration_status", default: 0
     t.date "registration_date"
+    t.integer "registration_status", default: 0
+    t.string "spire"
     t.boolean "subscribed_to_sms", default: false
     t.string "uid"
-    t.string "net_id"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["net_id"], name: "index_passengers_on_net_id"
     t.index ["spire"], name: "index_passengers_on_spire"
     t.index ["uid"], name: "index_passengers_on_uid"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "name"
-    t.string "spire"
     t.boolean "active"
     t.boolean "admin", default: false
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "uid"
+    t.string "name"
     t.string "net_id"
+    t.string "spire"
     t.string "title"
+    t.string "uid"
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["net_id"], name: "index_users_on_net_id"
     t.index ["spire"], name: "index_users_on_spire", unique: true
     t.index ["uid"], name: "index_users_on_uid"
@@ -89,5 +89,4 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_26_202921) do
     t.boolean "needs_contact_info", default: false
     t.index ["name"], name: "index_verifying_agencies_on_name", unique: true
   end
-
 end


### PR DESCRIPTION
Rails 8.1 alphabetizes column names. Figured it would be better to do this on its own rather than introduce a bunch of noise the next time someone actually writes a migration.