### PR TITLE
Flip over two remaining rails 8.1 defaults

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -43,7 +43,7 @@ Rails.configuration.active_support.escape_js_separators_in_json = false
 # The current behavior of not raising an error has been deprecated, and this configuration option will be removed in
 # Rails 8.2.
 #++
-# Rails.configuration.active_record.raise_on_missing_required_finder_order_columns = true
+Rails.configuration.active_record.raise_on_missing_required_finder_order_columns = true
 
 ###
 # Controls how Rails handles path relative URL redirects.
@@ -58,7 +58,7 @@ Rails.configuration.active_support.escape_js_separators_in_json = false
 # Applications that want to allow these redirects can set the config to `:log` (previous default)
 # to only log warnings, or `:notify` to send ActiveSupport notifications.
 #++
-# Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
+Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
 
 ###
 # Use a Ruby parser to track dependencies between Action View templates


### PR DESCRIPTION
They both _might_ result in exceptions, but unlikely. In the first case, calling `.first`, `.last` etc. will fail for relations that don't have an `order` _or_ a primary key. In the second, unsafe redirects will raise.